### PR TITLE
feat: add support for reverting LV back to state of snapshot 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ This variable is required. It supports one of the following values:
 
 - `clean`: Remove snapshots that conform to the specified prefix and pattern
 
+- `revert`: Revert to snapshots that are specifed by either the pattern or set.  If either the source LV or
+            snapshot are open, the merge is deferred until the next time the server reboots and the
+            source logical volume is activated.
+
 ### snapshot_lvm_set
 
 The snapshot role supports sets of volumes.  Sets may contain any number of volumes.

--- a/tasks/files/snapshot.py
+++ b/tasks/files/snapshot.py
@@ -10,6 +10,7 @@ import sys
 
 logger = logging.getLogger("snapshot-role")
 
+LVM_NOTFOUND_RC = 5
 MAX_LVM_NAME = 127
 CHUNK_SIZE = 65536
 
@@ -42,6 +43,7 @@ class SnapshotCommand:
     SNAPSHOT = "snapshot"
     SNAPSHOT_CHECK = "check"
     SNAPSHOT_CLEAN = "clean"
+    SNAPSHOT_REVERT = "revert"
 
 
 class SnapshotStatus:
@@ -69,6 +71,7 @@ class SnapshotStatus:
     ERROR_JSON_PARSER_ERROR = 21
     ERROR_INVALID_PERCENT_REQUESTED = 22
     ERROR_UNKNOWN_FAILURE = 23
+    ERROR_REVERT_FAILED = 24
 
 
 # what percentage is part of whole
@@ -252,6 +255,9 @@ def lvm_is_snapshot(vg_name, snapshot_name):
 
     rc, output = run_command(lvs_command)
 
+    if rc == LVM_NOTFOUND_RC:
+        return SnapshotStatus.SNAPSHOT_OK, False
+
     if rc:
         return SnapshotStatus.ERROR_LVS_FAILED, None
 
@@ -298,6 +304,75 @@ def lvm_snapshot_remove(vg_name, snapshot_name):
 
     if rc:
         return SnapshotStatus.ERROR_REMOVE_FAILED, output
+
+    return SnapshotStatus.SNAPSHOT_OK, ""
+
+
+def revert_lv(vg_name, lv_name, prefix, suffix):
+    snapshot_name = get_snapshot_name(lv_name, prefix, suffix)
+
+    rc, _vg_exists, lv_exists = lvm_lv_exists(vg_name, snapshot_name)
+
+    if lv_exists:
+        if not lvm_is_snapshot(vg_name, snapshot_name):
+            return (
+                SnapshotStatus.ERROR_REVERT_FAILED,
+                "LV with name: " + vg_name + "/" + snapshot_name + " is not a snapshot",
+            )
+    else:
+        return (
+            SnapshotStatus.ERROR_REVERT_FAILED,
+            "snapshot not found with name: " + vg_name + "/" + snapshot_name,
+        )
+
+    revert_command = ["lvconvert", "--merge", vg_name + "/" + snapshot_name]
+
+    rc, output = run_command(revert_command)
+
+    if rc:
+        return SnapshotStatus.ERROR_REVERT_FAILED, output
+
+    return SnapshotStatus.SNAPSHOT_OK, output
+
+
+def revert_lvs(vg_name, lv_name, prefix, suffix):
+    lvm_json = lvm_full_report_json()
+    report = lvm_json["report"]
+
+    # Revert snapshots
+    for list_item in report:
+        # The list contains items that are not VGs
+        try:
+            list_item["vg"]
+        except KeyError:
+            continue
+        vg = list_item["vg"][0]["vg_name"]
+        if vg_name and vg != vg_name:
+            continue
+
+        for lv in list_item["lv"]:
+            lv = lv["lv_name"]
+            if lv_name and lv != lv_name:
+                continue
+
+            # Make sure the source LV isn't a snapshot.
+            rc, is_snapshot = lvm_is_snapshot(vg, lv)
+
+            if rc != SnapshotStatus.SNAPSHOT_OK:
+                raise LvmBug("'lvs' failed '%d'" % rc)
+
+            if is_snapshot:
+                continue
+
+            rc, message = revert_lv(
+                vg,
+                lv,
+                prefix,
+                suffix,
+            )
+
+            if rc != SnapshotStatus.SNAPSHOT_OK:
+                return rc, message
 
     return SnapshotStatus.SNAPSHOT_OK, ""
 
@@ -552,6 +627,23 @@ def check_verify_lvs_completed(snapshot_all, vg_name, lv_name, prefix, suffix):
     return SnapshotStatus.SNAPSHOT_OK, ""
 
 
+def revert_snapshot_set(snapset_json):
+    snapset_name = snapset_json["name"]
+    volume_list = snapset_json["volumes"]
+    logger.info("clean snapsset : %s", snapset_name)
+
+    for list_item in volume_list:
+        vg = list_item["vg"]
+        lv = list_item["lv"]
+
+        rc, message = revert_lv(vg, lv, None, get_snapset_suffix(snapset_name))
+
+        if rc != SnapshotStatus.SNAPSHOT_OK:
+            return rc, message
+
+    return SnapshotStatus.SNAPSHOT_OK, ""
+
+
 def clean_snapshot_set(snapset_json):
     snapset_name = snapset_json["name"]
     volume_list = snapset_json["volumes"]
@@ -562,6 +654,14 @@ def clean_snapshot_set(snapset_json):
         lv = list_item["lv"]
 
         snapshot_name = get_snapshot_name(lv, None, get_snapset_suffix(snapset_name))
+
+        rc, vg_exists, lv_exists = lvm_lv_exists(vg, snapshot_name)
+
+        if not vg_exists or not lv_exists:
+            continue
+
+        if rc != SnapshotStatus.SNAPSHOT_OK:
+            return rc, "failed to get LV status"
 
         rc, message = lvm_snapshot_remove(vg, snapshot_name)
 
@@ -1051,11 +1151,13 @@ def validate_args(args):
         print("One of --prefix or --suffix is required : ", args.operation)
         sys.exit(SnapshotStatus.ERROR_CMD_INVALID)
 
-    rc, message, _required_space = get_required_space(args.required_space)
+    # not all commands include required_space
+    if hasattr(args, "required_space"):
+        rc, message, _required_space = get_required_space(args.required_space)
 
-    if rc != SnapshotStatus.SNAPSHOT_OK:
-        print(message)
-        sys.exit(SnapshotStatus.ERROR_CMD_INVALID)
+        if rc != SnapshotStatus.SNAPSHOT_OK:
+            print(message)
+            sys.exit(SnapshotStatus.ERROR_CMD_INVALID)
 
     return True
 
@@ -1282,6 +1384,50 @@ def clean_cmd(args):
     return rc, message
 
 
+def revert_cmd(args):
+    logger.info(
+        "revert_cmd: %s %s %s %s %s %d %s",
+        args.operation,
+        args.volume_group,
+        args.logical_volume,
+        args.suffix,
+        args.prefix,
+        args.verify,
+        args.set_json,
+    )
+
+    if args.set_json is None:
+        validate_args(args)
+
+        if args.verify:
+            rc, message = clean_verify_snapshots(
+                args.volume_group,
+                args.logical_volume,
+                args.prefix,
+                args.suffix,
+            )
+        else:
+            rc, message = revert_lvs(
+                args.volume_group,
+                args.logical_volume,
+                args.prefix,
+                args.suffix,
+            )
+    else:
+        rc, message, snapset_json = validate_snapset_json(
+            SnapshotCommand.SNAPSHOT_CHECK, args.set_json, args.verify
+        )
+        if rc != SnapshotStatus.SNAPSHOT_OK:
+            return rc, message
+
+        if args.verify:
+            rc, message = clean_verify_snapshot_set(snapset_json)
+        else:
+            rc, message = revert_snapshot_set(snapset_json)
+
+    return rc, message
+
+
 if __name__ == "__main__":
     set_up_logging()
 
@@ -1290,15 +1436,9 @@ if __name__ == "__main__":
     os.environ["LC_ALL"] = "C"
     os.environ["LVM_COMMAND_PROFILE"] = "lvmdbusd"
 
-    parser = argparse.ArgumentParser(description="Snapshot Operations")
-
-    # sub-parsers
-    subparsers = parser.add_subparsers(dest="operation", help="Available operations")
-
-    # sub-parser for 'snapshot'
-    snapshot_parser = subparsers.add_parser("snapshot", help="Snapshot given VG/LVs")
-    snapshot_parser.set_defaults(func=snapshot_cmd)
-    snapshot_parser.add_argument(
+    # arguments common to all operations
+    common_parser = argparse.ArgumentParser(add_help=False)
+    common_parser.add_argument(
         "-g",
         "--group",
         nargs="?",
@@ -1307,7 +1447,7 @@ if __name__ == "__main__":
         default=None,
         dest="set_json",
     )
-    snapshot_parser.add_argument(
+    common_parser.add_argument(
         "-a",
         "--all",
         action="store_true",
@@ -1315,7 +1455,7 @@ if __name__ == "__main__":
         dest="all",
         help="snapshot all VGs and LVs",
     )
-    snapshot_parser.add_argument(
+    common_parser.add_argument(
         "-vg",
         "--volumegroup",
         nargs="?",
@@ -1324,7 +1464,7 @@ if __name__ == "__main__":
         dest="volume_group",
         help="volume group to snapshot",
     )
-    snapshot_parser.add_argument(
+    common_parser.add_argument(
         "-lv",
         "--logicalvolume",
         nargs="?",
@@ -1333,8 +1473,36 @@ if __name__ == "__main__":
         dest="logical_volume",
         help="logical volume to snapshot",
     )
+    common_parser.add_argument(
+        "-s",
+        "--suffix",
+        dest="suffix",
+        type=str,
+        help="suffix to add to volume name for snapshot",
+    )
+    common_parser.add_argument(
+        "-p",
+        "--prefix",
+        dest="prefix",
+        type=str,
+        help="prefix to add to volume name for snapshot",
+    )
+
+    # arguments for operations that do verify
+    verify_parser = argparse.ArgumentParser(add_help=False)
+    verify_parser.add_argument(
+        "-v",
+        "--verify",
+        action="store_true",
+        default=False,
+        dest="verify",
+        help="verify VGs and LVs have snapshots",
+    )
+
+    # arguments for operations that deal with required space
+    req_space_parser = argparse.ArgumentParser(add_help=False)
     # TODO: range check required space - setting choices to a range makes the help ugly.
-    snapshot_parser.add_argument(
+    req_space_parser.add_argument(
         "-r",
         "--requiredspace",
         dest="required_space",
@@ -1343,152 +1511,39 @@ if __name__ == "__main__":
         default=20,
         help="percent of required space in the volume group to be reserved for snapshot",
     )
-    snapshot_parser.add_argument(
-        "-s",
-        "--suffix",
-        dest="suffix",
-        type=str,
-        help="suffix to add to volume name for snapshot",
+
+    parser = argparse.ArgumentParser(description="Snapshot Operations")
+
+    # sub-parsers
+    subparsers = parser.add_subparsers(dest="operation", help="Available operations")
+
+    # sub-parser for 'snapshot'
+    snapshot_parser = subparsers.add_parser(
+        "snapshot",
+        help="Snapshot given VG/LVs",
+        parents=[common_parser, req_space_parser],
     )
-    snapshot_parser.add_argument(
-        "-p",
-        "--prefix",
-        dest="prefix",
-        type=str,
-        help="prefix to add to volume name for snapshot",
-    )
+    snapshot_parser.set_defaults(func=snapshot_cmd)
 
     # sub-parser for 'check'
-    check_parser = subparsers.add_parser("check", help="Check space for given VG/LV")
-    check_parser.add_argument(
-        "-g",
-        "--group",
-        nargs="?",
-        action="store",
-        required=False,
-        default=None,
-        dest="set_json",
-    )
-    check_parser.add_argument(
-        "-a",
-        "--all",
-        action="store_true",
-        default=False,
-        dest="all",
-        help="check all VGs and LVs",
-    )
-    check_parser.add_argument(
-        "-v",
-        "--verify",
-        action="store_true",
-        default=False,
-        dest="verify",
-        help="verify VGs and LVs have snapshots",
-    )
-    check_parser.add_argument(
-        "-vg",
-        "--volumegroup",
-        nargs="?",
-        action="store",
-        default=None,
-        dest="volume_group",
-        help="volume group to check",
-    )
-    check_parser.add_argument(
-        "-lv",
-        "--logicalvolume",
-        nargs="?",
-        action="store",
-        default=None,
-        dest="logical_volume",
-        help="logical volume to check",
-    )
-    # TODO: range check required space - setting choices to a range makes the help ugly.
-    check_parser.add_argument(
-        "-r",
-        "--requiredspace",
-        dest="required_space",
-        default=20,
-        required=False,
-        type=int,  # choices=range(10,100),
-        help="percent of required space in the volume group to be reserved for check",
-    )
-    check_parser.add_argument(
-        "-s",
-        "--suffix",
-        dest="suffix",
-        type=str,
-        help="suffix to add to volume name for check - will verify no name conflicts",
-    )
-    check_parser.add_argument(
-        "-p",
-        "--prefix",
-        dest="prefix",
-        type=str,
-        help="prefix to add to volume name for check - will verify no name conflicts",
+    check_parser = subparsers.add_parser(
+        "check",
+        help="Check space for given VG/LV",
+        parents=[common_parser, req_space_parser, verify_parser],
     )
     check_parser.set_defaults(func=check_cmd)
 
     # sub-parser for 'clean'
-    clean_parser = subparsers.add_parser("clean", help="Cleanup snapshots")
-    clean_parser.add_argument(
-        "-g",
-        "--group",
-        nargs="?",
-        action="store",
-        required=False,
-        default=None,
-        dest="set_json",
-    )
-    clean_parser.add_argument(
-        "-a",
-        "--all",
-        action="store_true",
-        default=False,
-        dest="all",
-        help="clean all VGs and LVs",
-    )
-    clean_parser.add_argument(
-        "-v",
-        "--verify",
-        action="store_true",
-        default=False,
-        dest="verify",
-        help="verify VG and LV snapshots have been cleaned",
-    )
-    clean_parser.add_argument(
-        "-vg",
-        "--volumegroup",
-        nargs="?",
-        action="store",
-        default=None,
-        dest="volume_group",
-        help="volume group to cleanup/remove",
-    )
-    clean_parser.add_argument(
-        "-lv",
-        "--logicalvolume",
-        nargs="?",
-        action="store",
-        default=None,
-        dest="logical_volume",
-        help="logical volume to cleanup/remove",
-    )
-    clean_parser.add_argument(
-        "-s",
-        "--suffix",
-        dest="suffix",
-        type=str,
-        help="suffix to add to volume name for cleanup/remove",
-    )
-    clean_parser.add_argument(
-        "-p",
-        "--prefix",
-        dest="prefix",
-        type=str,
-        help="prefix to add to volume name for cleanup/remove",
+    clean_parser = subparsers.add_parser(
+        "clean", help="Cleanup snapshots", parents=[common_parser, verify_parser]
     )
     clean_parser.set_defaults(func=clean_cmd)
+
+    # sub-parser for 'revert'
+    revert_parser = subparsers.add_parser(
+        "revert", help="Revert to snapshots", parents=[common_parser, verify_parser]
+    )
+    revert_parser.set_defaults(func=revert_cmd)
 
     args = parser.parse_args()
     return_code, display_message = args.func(args)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,3 +29,7 @@
 - name: Verify Cleanup
   ansible.builtin.include_tasks: verify_cleanup.yml
   when: snapshot_lvm_action == "clean" and snapshot_lvm_verify_only
+
+- name: Revert to Snapshot
+  ansible.builtin.include_tasks: revert.yml
+  when: snapshot_lvm_action == "revert"

--- a/tasks/revert.yml
+++ b/tasks/revert.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Revert LV to snapshot
+  ansible.builtin.script: "{{ __snapshot_cmd }}"
+  args:
+    executable: "{{ __snapshot_python }}"
+  register: snapshot_cmd

--- a/tests/tests_revert_basic.yml
+++ b/tests/tests_revert_basic.yml
@@ -1,0 +1,129 @@
+---
+- name: Basic snapshot test
+  hosts: all
+  tasks:
+    - name: Run tests
+      block:
+        - name: Run the storage role to create test LVs
+          include_role:
+            name: fedora.linux_system_roles.storage
+
+        - name: Get unused disks
+          include_tasks: get_unused_disk.yml
+          vars:
+            min_size: "1g"
+            min_return: 10
+
+        - name: Set disk lists
+          set_fact:
+            disk_list_1: "{{ range(0, 3) | map('extract', unused_disks) |
+              list }}"
+            disk_list_2: "{{ range(3, 6) | map('extract', unused_disks) |
+              list }}"
+            disk_list_3: "{{ range(6, 10) | map('extract', unused_disks) |
+              list }}"
+
+        - name: Create LVM logical volumes under volume groups
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                volumes:
+                  - name: lv1
+                    size: "15%"
+                  - name: lv2
+                    size: "50%"
+              - name: test_vg2
+                disks: "{{ disk_list_2 }}"
+                volumes:
+                  - name: lv3
+                    size: "10%"
+                  - name: lv4
+                    size: "20%"
+              - name: test_vg3
+                disks: "{{ disk_list_3 }}"
+                volumes:
+                  - name: lv5
+                    size: "30%"
+                  - name: lv6
+                    size: "25%"
+                  - name: lv7
+                    size: "10%"
+                  - name: lv8
+                    size: "10%"
+
+        - name: Run the snapshot role to create snapshot LVs
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_percent_space_required: 15
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_suffix: _z
+            snapshot_lvm_prefix: a_
+            snapshot_lvm_action: snapshot
+
+        - name: Verify the snapshot LVs are created
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_suffix: _z
+            snapshot_lvm_prefix: a_
+            snapshot_lvm_verify_only: true
+            snapshot_lvm_action: check
+
+        - name: Revert the LVs to the snapshot
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_suffix: _z
+            snapshot_lvm_prefix: a_
+            snapshot_lvm_action: revert
+
+        - name: Use the snapshot_lvm_verify option to make sure revert is done
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_suffix: _z
+            snapshot_lvm_prefix: a_
+            snapshot_lvm_verify_only: true
+            snapshot_lvm_action: revert
+      always:
+        - name: Clean up storage volumes
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_safe_mode: false
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                state: absent
+                volumes:
+                  - name: lv1
+                    state: absent
+                  - name: lv2
+                    state: absent
+              - name: test_vg2
+                disks: "{{ disk_list_2 }}"
+                state: absent
+                volumes:
+                  - name: lv3
+                    state: absent
+                  - name: lv4
+                    state: absent
+              - name: test_vg3
+                disks: "{{ disk_list_3 }}"
+                state: absent
+                volumes:
+                  - name: lv5
+                    state: absent
+                  - name: lv6
+                    state: absent
+                  - name: lv7
+                    state: absent
+                  - name: lv8
+                    state: absent

--- a/tests/tests_set_revert.yml
+++ b/tests/tests_set_revert.yml
@@ -1,0 +1,141 @@
+---
+- name: Revert snapshots of logical volumes across different volume groups
+  hosts: all
+  vars:
+    snapshot_test_set:
+      name: snapset1
+      volumes:
+        - name: snapshot VG1 LV1
+          vg: test_vg1
+          lv: lv1
+          percent_space_required: 20
+        - name: snapshot VG2 LV3
+          vg: test_vg2
+          lv: lv3
+          percent_space_required: 15
+        - name: snapshot VG2 LV4
+          vg: test_vg2
+          lv: lv4
+          percent_space_required: 15
+        - name: snapshot VG3 LV7
+          vg: test_vg3
+          lv: lv7
+          percent_space_required: 15
+  tasks:
+    - name: Run tests
+      block:
+        - name: Run the storage role to create test LVs
+          include_role:
+            name: fedora.linux_system_roles.storage
+
+        - name: Get unused disks
+          include_tasks: get_unused_disk.yml
+          vars:
+            min_size: "1g"
+            min_return: 10
+
+        - name: Set disk lists
+          set_fact:
+            disk_list_1: "{{ range(0, 3) | map('extract', unused_disks) |
+              list }}"
+            disk_list_2: "{{ range(3, 6) | map('extract', unused_disks) |
+              list }}"
+            disk_list_3: "{{ range(6, 10) | map('extract', unused_disks) |
+              list }}"
+
+        - name: Create LVM logical volumes under volume groups
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                volumes:
+                  - name: lv1
+                    size: "15%"
+                  - name: lv2
+                    size: "50%"
+              - name: test_vg2
+                disks: "{{ disk_list_2 }}"
+                volumes:
+                  - name: lv3
+                    size: "10%"
+                  - name: lv4
+                    size: "20%"
+              - name: test_vg3
+                disks: "{{ disk_list_3 }}"
+                volumes:
+                  - name: lv5
+                    size: "30%"
+                  - name: lv6
+                    size: "25%"
+                  - name: lv7
+                    size: "10%"
+                  - name: lv8
+                    size: "10%"
+
+        - name: Run the snapshot role to create a snapshot set of LVs
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_action: snapshot
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+
+        - name: Verify the set of snapshots for the LVs
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_action: check
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+            snapshot_lvm_verify_only: true
+
+        - name: Revert the set
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_action: revert
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+
+        - name: Verify the revert is done with snapshot_lvm_verify_only
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_verify_only: true
+            snapshot_lvm_action: revert
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+
+      always:
+        - name: Clean up storage volumes
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_safe_mode: false
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                state: absent
+                volumes:
+                  - name: lv1
+                    state: absent
+                  - name: lv2
+                    state: absent
+              - name: test_vg2
+                disks: "{{ disk_list_2 }}"
+                state: absent
+                volumes:
+                  - name: lv3
+                    state: absent
+                  - name: lv4
+                    state: absent
+              - name: test_vg3
+                disks: "{{ disk_list_3 }}"
+                state: absent
+                volumes:
+                  - name: lv5
+                    state: absent
+                  - name: lv6
+                    state: absent
+                  - name: lv7
+                    state: absent
+                  - name: lv8
+                    state: absent

--- a/tests/tests_set_revert_no_snapshots_fail.yml
+++ b/tests/tests_set_revert_no_snapshots_fail.yml
@@ -1,0 +1,61 @@
+---
+- name: Verify snapshot action fails if no space is available
+  hosts: all
+  tasks:
+    - name: Run tests
+      block:
+        - name: Run the storage role to create test LVs
+          include_role:
+            name: fedora.linux_system_roles.storage
+
+        - name: Get unused disks
+          include_tasks: get_unused_disk.yml
+          vars:
+            min_size: "1g"
+            min_return: 10
+
+        - name: Set disk list
+          set_fact:
+            disk_list_1: "{{ range(0, 3) | map('extract', unused_disks) |
+              list }}"
+
+        - name: Create LVM logical volumes under volume groups
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                volumes:
+                  - name: lv1
+                    size: "50%"
+
+        - name: Test failure of reverting snapshot that doesn't exist
+          include_tasks: verify-role-failed.yml
+          vars:
+            __snapshot_failed_regex: "snapshot not found with name:*"
+            __snapshot_failed_msg: Role did not fail with no space error
+            __snapshot_failed_params:
+              snapshot_lvm_action: revert
+              __snapshot_lvm_set:
+                name: snapset1
+                volumes:
+                  - name: snapshot VG1 LV1
+                    vg: test_vg1
+                    lv: lv1
+                    percent_space_required: 50
+      always:
+        - name: Clean up storage volumes
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_safe_mode: false
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                state: absent
+                volumes:
+                  - name: lv1
+                    state: absent
+                  - name: lv2
+                    state: absent


### PR DESCRIPTION
Enhancement: add support for reverting LVs to snapshots

Reason: MVP requirements call for ability to revert snapshots

Use the lvconvert --merge command to revert the changes made to the
LVM logical volume.

If either the source LV or snapshot are open, the merge is deferred
until the next time the server reboots and thesource logical volume
is activated.

Result: Users can revert to snapshots

Issue Tracker Tickets (Jira or BZ if any):
