### PR TITLE
feat: add support to extending existing snapshots to required percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ This variable is required. It supports one of the following values:
             snapshot are open, the merge is deferred until the next time the server reboots and the
             source logical volume is activated.
 
+- `extend`: Extend snapshot to have at least snapshot_lvm_percent_space_required space allocated to the
+            snapshot.  Allocations are rounded up to the next multiple of the volume group extent size.
+
 ### snapshot_lvm_set
 
 The snapshot role supports sets of volumes.  Sets may contain any number of volumes.

--- a/tasks/extend.yml
+++ b/tasks/extend.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Extend Snapshot
+  ansible.builtin.script: "{{ __snapshot_cmd }}"
+  args:
+    executable: "{{ __snapshot_python }}"
+  register: snapshot_cmd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,3 +33,7 @@
 - name: Revert to Snapshot
   ansible.builtin.include_tasks: revert.yml
   when: snapshot_lvm_action == "revert"
+
+- name: Extend Snapshots
+  ansible.builtin.include_tasks: extend.yml
+  when: snapshot_lvm_action == "extend"

--- a/tests/tests_extend_basic.yml
+++ b/tests/tests_extend_basic.yml
@@ -1,0 +1,131 @@
+---
+- name: Basic snapshot test
+  hosts: all
+  tasks:
+    - name: Run tests
+      block:
+        - name: Run the storage role to create test LVs
+          include_role:
+            name: fedora.linux_system_roles.storage
+
+        - name: Get unused disks
+          include_tasks: get_unused_disk.yml
+          vars:
+            min_size: "1g"
+            min_return: 10
+
+        - name: Set disk lists
+          set_fact:
+            disk_list_1: "{{ range(0, 3) | map('extract', unused_disks) |
+              list }}"
+            disk_list_2: "{{ range(3, 6) | map('extract', unused_disks) |
+              list }}"
+            disk_list_3: "{{ range(6, 10) | map('extract', unused_disks) |
+              list }}"
+
+        - name: Create LVM logical volumes under volume groups
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                volumes:
+                  - name: lv1
+                    size: "10%"
+                  - name: lv2
+                    size: "10%"
+              - name: test_vg2
+                disks: "{{ disk_list_2 }}"
+                volumes:
+                  - name: lv3
+                    size: "10%"
+                  - name: lv4
+                    size: "10%"
+              - name: test_vg3
+                disks: "{{ disk_list_3 }}"
+                volumes:
+                  - name: lv5
+                    size: "10%"
+                  - name: lv6
+                    size: "10%"
+                  - name: lv7
+                    size: "10%"
+                  - name: lv8
+                    size: "10%"
+
+        - name: Run the snapshot role to create snapshot LVs
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_percent_space_required: 15
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_suffix: _z
+            snapshot_lvm_prefix: a_
+            snapshot_lvm_action: snapshot
+
+        - name: Verify the snapshot LVs are created
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_suffix: _z
+            snapshot_lvm_prefix: a_
+            snapshot_lvm_verify_only: true
+            snapshot_lvm_action: check
+
+        - name: Extend the snapshots size to 40 percent of the source
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_percent_space_required: 40
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_suffix: _z
+            snapshot_lvm_prefix: a_
+            snapshot_lvm_action: extend
+
+        - name: Use the snapshot_lvm_verify option to make sure extend is done
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_percent_space_required: 40
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_suffix: _z
+            snapshot_lvm_prefix: a_
+            snapshot_lvm_verify_only: true
+            snapshot_lvm_action: extend
+      always:
+        - name: Clean up storage volumes
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_safe_mode: false
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                state: absent
+                volumes:
+                  - name: lv1
+                    state: absent
+                  - name: lv2
+                    state: absent
+              - name: test_vg2
+                disks: "{{ disk_list_2 }}"
+                state: absent
+                volumes:
+                  - name: lv3
+                    state: absent
+                  - name: lv4
+                    state: absent
+              - name: test_vg3
+                disks: "{{ disk_list_3 }}"
+                state: absent
+                volumes:
+                  - name: lv5
+                    state: absent
+                  - name: lv6
+                    state: absent
+                  - name: lv7
+                    state: absent
+                  - name: lv8
+                    state: absent

--- a/tests/tests_set_extend.yml
+++ b/tests/tests_set_extend.yml
@@ -1,0 +1,161 @@
+---
+- name: Revert snapshots of logical volumes across different volume groups
+  hosts: all
+  vars:
+    snapshot_test_set:
+      name: snapset1
+      volumes:
+        - name: snapshot VG1 LV1
+          vg: test_vg1
+          lv: lv1
+          percent_space_required: 15
+        - name: snapshot VG2 LV3
+          vg: test_vg2
+          lv: lv3
+          percent_space_required: 15
+        - name: snapshot VG2 LV4
+          vg: test_vg2
+          lv: lv4
+          percent_space_required: 15
+        - name: snapshot VG3 LV7
+          vg: test_vg3
+          lv: lv7
+          percent_space_required: 15
+
+    snapshot_extend_set:
+      name: snapset1
+      volumes:
+        - name: snapshot VG1 LV1
+          vg: test_vg1
+          lv: lv1
+          percent_space_required: 30
+        - name: snapshot VG2 LV3
+          vg: test_vg2
+          lv: lv3
+          percent_space_required: 30
+        - name: snapshot VG2 LV4
+          vg: test_vg2
+          lv: lv4
+          percent_space_required: 30
+        - name: snapshot VG3 LV7
+          vg: test_vg3
+          lv: lv7
+          percent_space_required: 30
+  tasks:
+    - name: Run tests
+      block:
+        - name: Run the storage role to create test LVs
+          include_role:
+            name: fedora.linux_system_roles.storage
+
+        - name: Get unused disks
+          include_tasks: get_unused_disk.yml
+          vars:
+            min_size: "1g"
+            min_return: 10
+
+        - name: Set disk lists
+          set_fact:
+            disk_list_1: "{{ range(0, 3) | map('extract', unused_disks) |
+              list }}"
+            disk_list_2: "{{ range(3, 6) | map('extract', unused_disks) |
+              list }}"
+            disk_list_3: "{{ range(6, 10) | map('extract', unused_disks) |
+              list }}"
+
+        - name: Create LVM logical volumes under volume groups
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                volumes:
+                  - name: lv1
+                    size: "15%"
+                  - name: lv2
+                    size: "50%"
+              - name: test_vg2
+                disks: "{{ disk_list_2 }}"
+                volumes:
+                  - name: lv3
+                    size: "10%"
+                  - name: lv4
+                    size: "20%"
+              - name: test_vg3
+                disks: "{{ disk_list_3 }}"
+                volumes:
+                  - name: lv5
+                    size: "30%"
+                  - name: lv6
+                    size: "25%"
+                  - name: lv7
+                    size: "10%"
+                  - name: lv8
+                    size: "10%"
+
+        - name: Run the snapshot role to create a snapshot set of LVs
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_action: snapshot
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+
+        - name: Verify the set of snapshots for the LVs
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_action: check
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+            snapshot_lvm_verify_only: true
+
+        - name: Extend the set
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_action: extend
+            snapshot_lvm_set: "{{ snapshot_extend_set }}"
+
+        - name: Verify the revert is done with snapshot_lvm_verify_only
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_verify_only: true
+            snapshot_lvm_action: extend
+            snapshot_lvm_set: "{{ snapshot_extend_set }}"
+
+      always:
+        - name: Clean up storage volumes
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_safe_mode: false
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                state: absent
+                volumes:
+                  - name: lv1
+                    state: absent
+                  - name: lv2
+                    state: absent
+              - name: test_vg2
+                disks: "{{ disk_list_2 }}"
+                state: absent
+                volumes:
+                  - name: lv3
+                    state: absent
+                  - name: lv4
+                    state: absent
+              - name: test_vg3
+                disks: "{{ disk_list_3 }}"
+                state: absent
+                volumes:
+                  - name: lv5
+                    state: absent
+                  - name: lv6
+                    state: absent
+                  - name: lv7
+                    state: absent
+                  - name: lv8
+                    state: absent

--- a/tests/tests_set_extend_verify_fail.yml
+++ b/tests/tests_set_extend_verify_fail.yml
@@ -1,0 +1,86 @@
+---
+- name: Verify the extend verify commmand fails when space too low
+  hosts: all
+  vars:
+    snapshot_test_set:
+      name: snapset1
+      volumes:
+        - name: snapshot VG1 LV1
+          vg: test_vg1
+          lv: lv1
+          percent_space_required: 20
+    snapshot_test_verify_set:
+      name: snapset1
+      volumes:
+        - name: snapshot VG1 LV1
+          vg: test_vg1
+          lv: lv1
+          percent_space_required: 50
+  tasks:
+    - name: Run tests
+      block:
+        - name: Run the storage role to create test LVs
+          include_role:
+            name: fedora.linux_system_roles.storage
+
+        - name: Get unused disks
+          include_tasks: get_unused_disk.yml
+          vars:
+            min_size: "1g"
+            min_return: 10
+
+        - name: Set disk list
+          set_fact:
+            disk_list_1: "{{ range(0, 3) | map('extract', unused_disks) |
+              list }}"
+
+        - name: Create LVM logical volumes under volume groups
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                volumes:
+                  - name: lv1
+                    size: "50%"
+
+        - name: Run the snapshot role to create snapshot set of LVs
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_action: snapshot
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+
+        - name: Run the snapshot role to verify the set of snapshots for the LVs
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_action: check
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+            snapshot_lvm_verify_only: true
+
+        - name: Test failure extend verify
+          include_tasks: verify-role-failed.yml
+          vars:
+            __snapshot_failed_regex:
+              "verify failed due to insufficient space for:*"
+            __snapshot_failed_msg: Role did not fail with extend verify
+            __snapshot_failed_params:
+              snapshot_lvm_action: extend
+              snapshot_lvm_verify_only: true
+              __snapshot_lvm_set: "{{ snapshot_test_verify_set }}"
+
+      always:
+        - name: Clean up storage volumes
+          include_role:
+            name: fedora.linux_system_roles.storage
+          vars:
+            storage_safe_mode: false
+            storage_pools:
+              - name: test_vg1
+                disks: "{{ disk_list_1 }}"
+                state: absent
+                volumes:
+                  - name: lv1
+                    state: absent


### PR DESCRIPTION
Reason: MVP requirements call for managment of snapshots as sets

Result: Users can set minimum space available percentage for snapshots

Enhancement:

Use lvextend to extend snapshots to the requested percentage of the source LV.  Allocated space is calculated and rounded up to the extent size for the volume group.

Issue Tracker Tickets (Jira or BZ if any):
