### PR TITLE
feat: add support for the "list" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,11 @@ Sets are defined in the following format:
 
 If before running the role, with :
 
-### snapshot_lvm_prefix
+### snapshot_lvm_snapset_name
 
-This variable is required if not using sets. snapshot_lvm_prefix is a string that will be
-prepended to the name of the LV when the snapshot is created.
-
-### snapshot_lvm_suffix
-
-This variable is required if not using sets. snapshot_lvm_prefix is a string that will be
-appended to the name of the LV when the snapshot is created.
+This variable is required. snapshot_lvm_snapset_name is a string that will be
+appended to the name of the LV when the snapshot set is created.  It will be used
+to identify members of the set.
 
 If before running the role, the following LVs exist:
 
@@ -94,29 +90,29 @@ lv1_vg3 vg3  -wi-a-----   1.00g
 lv3_vg3 vg3  -wi-a----- 120.00m
 ```
 
-If the prefix is set to "a_" and the suffix is set to "_z", running the role will result
+If snapshot_lvm_snapset_name is set to "_snapset1", running the role will result
 in the following:
 
 ```text
-LV          VG   Attr       LSize   Pool Origin  Data%  Meta%  Move Log Cpy%Sync Convert
-a_home_z    rhel swi-a-s--- 104.00m      home    0.00
-a_root_z    rhel swi-a-s---   3.50g      root    0.01
-a_swap_z    rhel swi-a-s--- 400.00m      swap    0.00
-home        rhel owi-aos---   1.00g
-root        rhel owi-aos---  35.00g
-swap        rhel owi-aos---  <3.88g
-a_lv1_vg1_z vg1  swi-a-s--- 104.00m      lv1_vg1 0.00
-a_lv2_vg1_z vg1  swi-a-s---   8.00m      lv2_vg1 0.00
-lv1_vg1     vg1  owi-a-s---   1.00g
-lv2_vg1     vg1  owi-a-s---  40.00m
-a_lv1_vg2_z vg2  swi-a-s--- 104.00m      lv1_vg2 0.00
-a_lv2_vg2_z vg2  swi-a-s---  12.00m      lv2_vg2 0.00
-lv1_vg2     vg2  owi-a-s---   1.00g
-lv2_vg2     vg2  owi-a-s---  80.00m
-a_lv1_vg3_z vg3  swi-a-s--- 104.00m      lv1_vg3 0.00
-a_lv3_vg3_z vg3  swi-a-s---  16.00m      lv3_vg3 0.00
-lv1_vg3     vg3  owi-a-s---   1.00g
-lv3_vg3     vg3  owi-a-s--- 120.00m
+LV               VG   Attr       LSize   Pool Origin  Data%  Meta%  Move Log Cpy%Sync Convert
+home_snapset1    rhel swi-a-s--- 104.00m      home    0.00
+root_snapset1    rhel swi-a-s---   3.50g      root    0.01
+swap_snapset1    rhel swi-a-s--- 400.00m      swap    0.00
+home             rhel owi-aos---   1.00g
+root             rhel owi-aos---  35.00g
+swap             rhel owi-aos---  <3.88g
+lv1_vg1_snapset1 vg1  swi-a-s--- 104.00m      lv1_vg1 0.00
+lv2_vg1_snapset1 vg1  swi-a-s---   8.00m      lv2_vg1 0.00
+lv1_vg1          vg1  owi-a-s---   1.00g
+lv2_vg1          vg1  owi-a-s---  40.00m
+lv1_vg2_snapset1 vg2  swi-a-s--- 104.00m      lv1_vg2 0.00
+lv2_vg2_snapset1 vg2  swi-a-s---  12.00m      lv2_vg2 0.00
+lv1_vg2          vg2  owi-a-s---   1.00g
+lv2_vg2          vg2  owi-a-s---  80.00m
+lv1_vg3_snapset1 vg3  swi-a-s--- 104.00m      lv1_vg3 0.00
+lv3_vg3_snapset1 vg3  swi-a-s---  16.00m      lv3_vg3 0.00
+lv1_vg3          vg3  owi-a-s---   1.00g
+lv3_vg3          vg3  owi-a-s--- 120.00m
 ```
 
 ### snapshot_lvm_percent_space_required

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ If before running the role, with :
 
 This variable is required. snapshot_lvm_snapset_name is a string that will be
 appended to the name of the LV when the snapshot set is created.  It will be used
-to identify members of the set.
+to identify members of the set.  It must be at least one character long and contain
+valid characters for use in an LVM volume name. A to Z, a to z, 0 to 9, underscore (_),
+hyphen (-), dot (.), and plus (+) are valid characters.
 
 If before running the role, the following LVs exist:
 
@@ -151,6 +153,280 @@ be removed by the remove command without snapshot_lvm_verify_only.
 
 snapshot_lvm_verify_only is intended to be used to double check that the snapshot or
 remove command have completed the operation correctly.
+
+### Variables Exported by the Role
+
+#### snapshot_facts
+
+Contains volume and mount point information for a given snapset.
+
+For example:
+
+```json
+{
+    "volumes": {
+        "vg3": [
+            {
+                "lv_uuid": "VY7oRQ-zB1q-DzsP-1y7G-J3gL-ci1e-nQXwAy",
+                "lv_name": "lv1_vg3",
+                "lv_full_name": "vg3/lv1_vg3",
+                "lv_path": "/dev/vg3/lv1_vg3",
+                "lv_size": "1073741824",
+                "origin": "",
+                "origin_size": "1073741824",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "owi-a-s---",
+                "vg_name": "vg3",
+                "data_percent": "",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "Yhn7RG-k7pM-ylf9-NNt8-xuGI-WwrF-i0Pf6T",
+                "lv_name": "lv1_vg3_snapset2",
+                "lv_full_name": "vg3/lv1_vg3_snapset2",
+                "lv_path": "/dev/vg3/lv1_vg3_snapset2",
+                "lv_size": "322961408",
+                "origin": "lv1_vg3",
+                "origin_size": "1073741824",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "swi-a-s---",
+                "vg_name": "vg3",
+                "data_percent": "0.00",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "NlwbxX-NhwK-IHTj-sV9k-ldZY-Twvj-2SiCVe",
+                "lv_name": "lv2_vg3",
+                "lv_full_name": "vg3/lv2_vg3",
+                "lv_path": "/dev/vg3/lv2_vg3",
+                "lv_size": "1073741824",
+                "origin": "",
+                "origin_size": "1073741824",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "owi-a-s---",
+                "vg_name": "vg3",
+                "data_percent": "",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "j0RCzX-OVaA-MGDw-ejHO-Eu35-f4yG-VJL2Kr",
+                "lv_name": "lv2_vg3_snapset2",
+                "lv_full_name": "vg3/lv2_vg3_snapset2",
+                "lv_path": "/dev/vg3/lv2_vg3_snapset2",
+                "lv_size": "322961408",
+                "origin": "lv2_vg3",
+                "origin_size": "1073741824",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "swi-aos---",
+                "vg_name": "vg3",
+                "data_percent": "0.66",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "8kfTDY-22SL-4tC7-vTsR-1R63-zVzq-55qEL3",
+                "lv_name": "lv3_vg3",
+                "lv_full_name": "vg3/lv3_vg3",
+                "lv_path": "/dev/vg3/lv3_vg3",
+                "lv_size": "125829120",
+                "origin": "",
+                "origin_size": "125829120",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "owi-a-s---",
+                "vg_name": "vg3",
+                "data_percent": "",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "babChm-IzEN-Pf8q-1dxk-BJ9R-3kZb-u91utS",
+                "lv_name": "lv3_vg3_snapset2",
+                "lv_full_name": "vg3/lv3_vg3_snapset2",
+                "lv_path": "/dev/vg3/lv3_vg3_snapset2",
+                "lv_size": "41943040",
+                "origin": "lv3_vg3",
+                "origin_size": "125829120",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "swi-a-s---",
+                "vg_name": "vg3",
+                "data_percent": "0.00",
+                "metadata_percent": ""
+            }
+        ],
+        "vg2": [
+            {
+                "lv_uuid": "8uMuRW-1KCV-8FTJ-frhX-X39o-V15B-1uEC98",
+                "lv_name": "lv1_vg2",
+                "lv_full_name": "vg2/lv1_vg2",
+                "lv_path": "/dev/vg2/lv1_vg2",
+                "lv_size": "1073741824",
+                "origin": "",
+                "origin_size": "1073741824",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "owi-a-s---",
+                "vg_name": "vg2",
+                "data_percent": "",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "GGssIK-SHYI-to1m-MhVL-2BDk-PJ8X-dBnL7G",
+                "lv_name": "lv1_vg2_snapset2",
+                "lv_full_name": "vg2/lv1_vg2_snapset2",
+                "lv_path": "/dev/vg2/lv1_vg2_snapset2",
+                "lv_size": "322961408",
+                "origin": "lv1_vg2",
+                "origin_size": "1073741824",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "swi-aos---",
+                "vg_name": "vg2",
+                "data_percent": "20.97",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "83A9VM-kVEy-sc60-kF14-gKGb-5Ryj-7yDyEG",
+                "lv_name": "lv2_vg2",
+                "lv_full_name": "vg2/lv2_vg2",
+                "lv_path": "/dev/vg2/lv2_vg2",
+                "lv_size": "83886080",
+                "origin": "",
+                "origin_size": "83886080",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "owi-a-s---",
+                "vg_name": "vg2",
+                "data_percent": "",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "6tVL8A-U1x1-qqUt-WFVG-POsG-msFs-ZbbPq1",
+                "lv_name": "lv2_vg2_snapset2",
+                "lv_full_name": "vg2/lv2_vg2_snapset2",
+                "lv_path": "/dev/vg2/lv2_vg2_snapset2",
+                "lv_size": "29360128",
+                "origin": "lv2_vg2",
+                "origin_size": "83886080",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "swi-a-s---",
+                "vg_name": "vg2",
+                "data_percent": "0.00",
+                "metadata_percent": ""
+            }
+        ],
+        "vg1": [
+            {
+                "lv_uuid": "UnN0s0-TauJ-csnN-BgC1-3ocI-p8bE-jz0Hd8",
+                "lv_name": "lv1_vg1",
+                "lv_full_name": "vg1/lv1_vg1",
+                "lv_path": "/dev/vg1/lv1_vg1",
+                "lv_size": "1073741824",
+                "origin": "",
+                "origin_size": "1073741824",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "owi-aos---",
+                "vg_name": "vg1",
+                "data_percent": "",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "5Np7N9-H15x-Go96-fIwL-E0GR-4fVB-clLDW2",
+                "lv_name": "lv1_vg1_snapset2",
+                "lv_full_name": "vg1/lv1_vg1_snapset2",
+                "lv_path": "/dev/vg1/lv1_vg1_snapset2",
+                "lv_size": "322961408",
+                "origin": "lv1_vg1",
+                "origin_size": "1073741824",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "swi-a-s---",
+                "vg_name": "vg1",
+                "data_percent": "20.97",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "P0LPUQ-CljS-hOEm-U749-yyr9-USE7-1qDc2N",
+                "lv_name": "lv2_vg1",
+                "lv_full_name": "vg1/lv2_vg1",
+                "lv_path": "/dev/vg1/lv2_vg1",
+                "lv_size": "41943040",
+                "origin": "",
+                "origin_size": "41943040",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "owi-a-s---",
+                "vg_name": "vg1",
+                "data_percent": "",
+                "metadata_percent": ""
+            },
+            {
+                "lv_uuid": "FYIBRe-FDiW-PDUE-3l1y-mLzN-bLEg-qF12cz",
+                "lv_name": "lv2_vg1_snapset2",
+                "lv_full_name": "vg1/lv2_vg1_snapset2",
+                "lv_path": "/dev/vg1/lv2_vg1_snapset2",
+                "lv_size": "16777216",
+                "origin": "lv2_vg1",
+                "origin_size": "41943040",
+                "pool_lv": "",
+                "lv_tags": "",
+                "lv_attr": "swi-a-s---",
+                "vg_name": "vg1",
+                "data_percent": "0.00",
+                "metadata_percent": ""
+            }
+        ]
+    },
+    "mounts": {
+        "/dev/vg3/lv1_vg3": null,
+        "/dev/vg3/lv1_vg3_snapset2": [
+            {
+                "TARGET": "/mnt/database",
+                "SOURCE": "/dev/mapper/vg3-lv1_vg3_snapset2",
+                "FSTYPE": "xfs",
+                "OPTIONS": "rw,relatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota"
+            }
+        ],
+        "/dev/vg3/lv2_vg3": null,
+        "/dev/vg3/lv2_vg3_snapset2": null,
+        "/dev/vg3/lv3_vg3": null,
+        "/dev/vg3/lv3_vg3_snapset2": null,
+        "/dev/vg2/lv1_vg2": null,
+        "/dev/vg2/lv1_vg2_snapset2": [
+            {
+                "TARGET": "/mnt/production_mnt",
+                "SOURCE": "/dev/mapper/vg2-lv1_vg2_snapset2",
+                "FSTYPE": "xfs",
+                "OPTIONS": "rw,relatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota"
+            }
+        ],
+        "/dev/vg2/lv2_vg2": null,
+        "/dev/vg2/lv2_vg2_snapset2": null,
+        "/dev/vg1/lv1_vg1": null,
+        "/dev/vg1/lv1_vg1_snapset2": [
+            {
+                "TARGET": "/mnt/new_mountpoint",
+                "SOURCE": "/dev/mapper/vg1-lv1_vg1_snapset2",
+                "FSTYPE": "xfs",
+                "OPTIONS": "rw,relatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota"
+            },
+            {
+                "TARGET": "/mnt/other_mp",
+                "SOURCE": "/dev/mapper/vg1-lv1_vg1_snapset2",
+                "FSTYPE": "xfs",
+                "OPTIONS": "rw,relatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota"
+            }
+        ],
+        "/dev/vg1/lv2_vg1": null,
+        "/dev/vg1/lv2_vg1_snapset2": null
+    }
+}
+```
 
 ## rpm-ostree
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,6 @@ snapshot_lvm_all_vgs: false
 snapshot_lvm_verify_only: false
 snapshot_lvm_vg: ''
 snapshot_lvm_lv: ''
-snapshot_lvm_prefix: ''
-snapshot_lvm_suffix: ''
+snapshot_lvm_snapset_name: ''
 snapshot_lvm_percent_space_required: ''
 snapshot_lvm_set: ''

--- a/examples/check_space.yml
+++ b/examples/check_space.yml
@@ -4,8 +4,7 @@
   hosts: all
   vars:
     snapshot_lvm_action: check
-    snapshot_lvm_prefix: a_
-    snapshot_lvm_suffix: _z
+    snapshot_lvm_snapset_name: snapset1
     snapshot_lvm_percent_space_required: 20
     snapshot_lvm_all_vgs: true
   roles:

--- a/examples/remove_all.yml
+++ b/examples/remove_all.yml
@@ -4,8 +4,7 @@
   hosts: all
   vars:
     snapshot_lvm_action: remove
-    snapshot_lvm_prefix: a_
-    snapshot_lvm_suffix: _z
+    snapshot_lvm_snapset_name: snapset1
     snapshot_lvm_all_vgs: true
   roles:
     - linux-system-roles.snapshot

--- a/examples/snapshot_all.yml
+++ b/examples/snapshot_all.yml
@@ -4,8 +4,7 @@
   hosts: all
   vars:
     snapshot_lvm_action: snapshot
-    snapshot_lvm_prefix: a_
-    snapshot_lvm_suffix: _z
+    snapshot_lvm_snapset_name: snapset1
     snapshot_lvm_percent_space_required: 20
     snapshot_lvm_all_vgs: true
   roles:

--- a/tasks/files/snapshot.py
+++ b/tasks/files/snapshot.py
@@ -213,7 +213,7 @@ def get_snapshot_name(lv_name, prefix, suffix):
     else:
         suffix_str = ""
 
-    return prefix_str + lv_name + suffix_str
+    return prefix_str + lv_name + "_" + suffix_str
 
 
 def lvm_lv_exists(vg_name, lv_name):
@@ -493,7 +493,7 @@ def extend_snapshot_set(snapset_json):
         percent_space_required = list_item["percent_space_required"]
 
         rc, message = extend_lv_snapshot(
-            vg, lv, None, get_snapset_suffix(snapset_name), percent_space_required
+            vg, lv, None, snapset_name, percent_space_required
         )
 
         if rc != SnapshotStatus.SNAPSHOT_OK:
@@ -513,7 +513,7 @@ def extend_verify_snapshot_set(snapset_json):
         lv = list_item["lv"]
         percent_space_required = list_item["percent_space_required"]
 
-        snapshot_name = get_snapshot_name(lv, None, get_snapset_suffix(snapset_name))
+        snapshot_name = get_snapshot_name(lv, None, snapset_name)
 
         rc, _vg_exists, lv_exists = lvm_lv_exists(vg, snapshot_name)
         if rc != SnapshotStatus.SNAPSHOT_OK:
@@ -815,7 +815,7 @@ def check_verify_lvs_set(snapset_json):
         vg = list_item["vg"]
         lv = list_item["lv"]
 
-        snapshot_name = get_snapshot_name(lv, None, get_snapset_suffix(snapset_name))
+        snapshot_name = get_snapshot_name(lv, None, snapset_name)
 
         rc, _vg_exists, lv_exists = lvm_lv_exists(vg, snapshot_name)
         if rc != SnapshotStatus.SNAPSHOT_OK:
@@ -933,7 +933,8 @@ def revert_snapshot_set(snapset_json):
         vg = list_item["vg"]
         lv = list_item["lv"]
 
-        rc, message = revert_lv(vg, lv, None, get_snapset_suffix(snapset_name))
+        rc, message = revert_lv(
+            vg, lv, None, get_snapshot_name(lv, None, snapset_name))
 
         if rc != SnapshotStatus.SNAPSHOT_OK:
             return rc, message
@@ -950,7 +951,7 @@ def remove_snapshot_set(snapset_json):
     for list_item in volume_list:
         vg = list_item["vg"]
         lv = list_item["lv"]
-        snapshot_name = get_snapshot_name(lv, None, get_snapset_suffix(snapset_name))
+        snapshot_name = get_snapshot_name(lv, None, snapset_name)
 
         rc, vg_exists, lv_exists = lvm_lv_exists(vg, snapshot_name)
 
@@ -973,7 +974,7 @@ def remove_snapshot_set(snapset_json):
         vg = list_item["vg"]
         lv = list_item["lv"]
 
-        snapshot_name = get_snapshot_name(lv, None, get_snapset_suffix(snapset_name))
+        snapshot_name = get_snapshot_name(lv, None, snapset_name)
 
         rc, vg_exists, lv_exists = lvm_lv_exists(vg, snapshot_name)
         if rc != SnapshotStatus.SNAPSHOT_OK:
@@ -1001,7 +1002,7 @@ def remove_verify_snapshot_set(snapset_json):
         vg = list_item["vg"]
         lv = list_item["lv"]
 
-        snapshot_name = get_snapshot_name(lv, None, get_snapset_suffix(snapset_name))
+        snapshot_name = get_snapshot_name(lv, None, snapset_name)
 
         rc, _vg_exists, lv_exists = lvm_lv_exists(vg, snapshot_name)
         if rc != SnapshotStatus.SNAPSHOT_OK:
@@ -1211,7 +1212,7 @@ def verify_snapset_target_no_existing(snapset_json):
         vg = list_item["vg"]
         lv = list_item["lv"]
 
-        snapshot_name = get_snapshot_name(lv, None, get_snapset_suffix(snapset_name))
+        snapshot_name = get_snapshot_name(lv, None, snapset_name)
 
         rc, _vg_exists, lv_exists = lvm_lv_exists(vg, snapshot_name)
         if rc != SnapshotStatus.SNAPSHOT_OK:
@@ -1259,10 +1260,6 @@ def verify_snapset_source_lvs_exist(snapset_json):
     return SnapshotStatus.SNAPSHOT_OK, ""
 
 
-def get_snapset_suffix(snapset_name):
-    return "_" + snapset_name
-
-
 def verify_snapset_names(snapset_json):
     snapset_name = snapset_json["name"]
     volume_list = snapset_json["volumes"]
@@ -1270,9 +1267,7 @@ def verify_snapset_names(snapset_json):
     for list_item in volume_list:
         lv = list_item["lv"]
 
-        rc, message = check_name_for_snapshot(
-            lv, None, get_snapset_suffix(snapset_name)
-        )
+        rc, message = check_name_for_snapshot(lv, None, snapset_name)
         if rc != SnapshotStatus.SNAPSHOT_OK:
             return rc, message
 
@@ -1379,9 +1374,7 @@ def snapshot_create_set(snapset_json):
             vg, lv, percent_space_required, current_space_dict
         )
 
-        rc, message = snapshot_lv(
-            vg, lv, None, get_snapset_suffix(snapset_name), required_size
-        )
+        rc, message = snapshot_lv(vg, lv, None, snapset_name, required_size)
         if rc != SnapshotStatus.SNAPSHOT_OK:
             return rc, message
 
@@ -1861,10 +1854,10 @@ if __name__ == "__main__":
     )
     common_parser.add_argument(
         "-s",
-        "--suffix",
+        "--snapset",
         dest="suffix",
         type=str,
-        help="suffix to add to volume name for snapshot",
+        help="name for snapshot set",
     )
     common_parser.add_argument(
         "-p",

--- a/tasks/list.yml
+++ b/tasks/list.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+---
+- name: List snapshots
+  ansible.builtin.script: "{{ __snapshot_cmd }}"
+  args:
+    executable: "{{ __snapshot_python }}"
+  register: snapshot_cmd
+
+- name: Print out response
+  debug:
+    var: snapshot_cmd.stdout
+    verbosity: 2
+
+- name: Set snapshot_facts to the JSON results
+  set_fact:
+    snapshot_facts: "{{ snapshot_cmd.stdout | from_json }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,10 @@
   ansible.builtin.include_tasks: revert.yml
   when: snapshot_lvm_action == "revert"
 
+- name: List Snapshot Attributes
+  ansible.builtin.include_tasks: list.yml
+  when: snapshot_lvm_action == "list"
+
 - name: Extend Snapshots
   ansible.builtin.include_tasks: extend.yml
   when: snapshot_lvm_action == "extend"

--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -60,8 +60,7 @@
           vars:
             snapshot_lvm_percent_space_required: 15
             snapshot_lvm_all_vgs: true
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: snapshot
 
         - name: Verify the snapshot LVs are created
@@ -69,8 +68,7 @@
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_all_vgs: true
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_verify_only: true
             snapshot_lvm_action: check
 
@@ -78,16 +76,14 @@
           include_role:
             name: linux-system-roles.snapshot
           vars:
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: remove
 
         - name: Use the snapshot_lvm_verify option to make sure remove is done
           include_role:
             name: linux-system-roles.snapshot
           vars:
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_verify_only: true
             snapshot_lvm_action: remove
       always:

--- a/tests/tests_check_no_lv_fail.yml
+++ b/tests/tests_check_no_lv_fail.yml
@@ -39,8 +39,7 @@
             __snapshot_failed_params:
               snapshot_lvm_vg: test_vg1
               snapshot_lvm_lv: xxxxx
-              snapshot_lvm_suffix: _z
-              snapshot_lvm_prefix: a_
+              snapshot_lvm_snapset_name: snapset1
               snapshot_lvm_verify_only: true
               snapshot_lvm_action: check
       always:

--- a/tests/tests_check_no_vg_fail.yml
+++ b/tests/tests_check_no_vg_fail.yml
@@ -37,8 +37,7 @@
             __snapshot_failed_msg: Role check did not fail with wrong VG
             __snapshot_failed_params:
               snapshot_lvm_vg: xxxxxx
-              snapshot_lvm_suffix: _z
-              snapshot_lvm_prefix: a_
+              snapshot_lvm_snapset_name: snapset1
               snapshot_lvm_verify_only: true
               snapshot_lvm_action: check
       always:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -6,8 +6,7 @@
   vars:
     snapshot_lvm_action: check
     snapshot_lvm_percent_space_required: 2
-    snapshot_lvm_prefix: a_
-    snapshot_lvm_suffix: _z
+    snapshot_lvm_snapset_name: snapset1
     snapshot_lvm_all_vgs: true
   roles:
     - linux-system-roles.snapshot

--- a/tests/tests_extend_basic.yml
+++ b/tests/tests_extend_basic.yml
@@ -60,8 +60,7 @@
           vars:
             snapshot_lvm_percent_space_required: 15
             snapshot_lvm_all_vgs: true
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: snapshot
 
         - name: Verify the snapshot LVs are created
@@ -69,8 +68,7 @@
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_all_vgs: true
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_verify_only: true
             snapshot_lvm_action: check
 
@@ -80,8 +78,7 @@
           vars:
             snapshot_lvm_percent_space_required: 40
             snapshot_lvm_all_vgs: true
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: extend
 
         - name: Use the snapshot_lvm_verify option to make sure extend is done
@@ -90,8 +87,7 @@
           vars:
             snapshot_lvm_percent_space_required: 40
             snapshot_lvm_all_vgs: true
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_verify_only: true
             snapshot_lvm_action: extend
       always:

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -5,8 +5,7 @@
   vars:
     snapshot_lvm_action: check
     snapshot_lvm_percent_space_required: 2
-    snapshot_lvm_prefix: a_
-    snapshot_lvm_suffix: _z
+    snapshot_lvm_snapset_name: snapset1
     snapshot_lvm_all_vgs: true
   tasks:
     - name: Run test in a block to clean up in always

--- a/tests/tests_list.yml
+++ b/tests/tests_list.yml
@@ -1,46 +1,6 @@
 ---
-- name: Revert snapshots of logical volumes across different volume groups
+- name: Basic snapshot test
   hosts: all
-  vars:
-    snapshot_test_set:
-      name: snapset1
-      volumes:
-        - name: snapshot VG1 LV1
-          vg: test_vg1
-          lv: lv1
-          percent_space_required: 15
-        - name: snapshot VG2 LV3
-          vg: test_vg2
-          lv: lv3
-          percent_space_required: 15
-        - name: snapshot VG2 LV4
-          vg: test_vg2
-          lv: lv4
-          percent_space_required: 15
-        - name: snapshot VG3 LV7
-          vg: test_vg3
-          lv: lv7
-          percent_space_required: 15
-
-    snapshot_extend_set:
-      name: snapset1
-      volumes:
-        - name: snapshot VG1 LV1
-          vg: test_vg1
-          lv: lv1
-          percent_space_required: 30
-        - name: snapshot VG2 LV3
-          vg: test_vg2
-          lv: lv3
-          percent_space_required: 30
-        - name: snapshot VG2 LV4
-          vg: test_vg2
-          lv: lv4
-          percent_space_required: 30
-        - name: snapshot VG3 LV7
-          vg: test_vg3
-          lv: lv7
-          percent_space_required: 30
   tasks:
     - name: Run tests
       block:
@@ -94,36 +54,45 @@
                   - name: lv8
                     size: "10%"
 
-        - name: Run the snapshot role to create a snapshot set of LVs
+        - name: Run the snapshot role to create snapshot LVs
           include_role:
             name: linux-system-roles.snapshot
           vars:
+            snapshot_lvm_percent_space_required: 15
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: snapshot
-            snapshot_lvm_set: "{{ snapshot_test_set }}"
 
-        - name: Verify the set of snapshots for the LVs
+        - name: Verify the snapshot LVs are created
           include_role:
             name: linux-system-roles.snapshot
           vars:
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_snapset_name: snapset1
+            snapshot_lvm_verify_only: true
             snapshot_lvm_action: check
-            snapshot_lvm_set: "{{ snapshot_test_set }}"
-            snapshot_lvm_verify_only: true
 
-        - name: Extend the set
+        - name: List
           include_role:
             name: linux-system-roles.snapshot
           vars:
-            snapshot_lvm_action: extend
-            snapshot_lvm_set: "{{ snapshot_extend_set }}"
+            snapshot_lvm_snapset_name: snapset1
+            snapshot_lvm_action: list
 
-        - name: Verify the extend is done
+        - name: Run the snapshot role remove the snapshot LVs
           include_role:
             name: linux-system-roles.snapshot
           vars:
-            snapshot_lvm_verify_only: true
-            snapshot_lvm_action: extend
-            snapshot_lvm_set: "{{ snapshot_extend_set }}"
+            snapshot_lvm_snapset_name: snapset1
+            snapshot_lvm_action: remove
 
+        - name: Use the snapshot_lvm_verify option to make sure remove is done
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_snapset_name: snapset1
+            snapshot_lvm_verify_only: true
+            snapshot_lvm_action: remove
       always:
         - name: Remove storage volumes
           include_role:

--- a/tests/tests_multi_snapsets.yml
+++ b/tests/tests_multi_snapsets.yml
@@ -1,5 +1,5 @@
 ---
-- name: Single VG snapshot test
+- name: Basic snapshot test
   hosts: all
   tasks:
     - name: Run tests
@@ -54,40 +54,70 @@
                   - name: lv8
                     size: "10%"
 
-        - name: Run the snapshot role to create snapshot of single LV
+        - name: Run the snapshot role to create snapshot LVs for snapset1
           include_role:
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_percent_space_required: 15
+            snapshot_lvm_vg: test_vg1
             snapshot_lvm_snapset_name: snapset1
-            snapshot_lvm_vg: test_vg2
             snapshot_lvm_action: snapshot
 
-        - name: Verify the snapshot LV is created
+        - name: Verify the snapshot LVs are createdf or snapset1
           include_role:
             name: linux-system-roles.snapshot
           vars:
+            snapshot_lvm_vg: test_vg1
             snapshot_lvm_snapset_name: snapset1
-            snapshot_lvm_vg: test_vg2
             snapshot_lvm_verify_only: true
             snapshot_lvm_action: check
 
-        - name: Run the snapshot role remove the snapshot for single LV
+        - name: Run the snapshot role to create snapshot LVs for snapset2
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_percent_space_required: 15
+            snapshot_lvm_vg: test_vg2
+            snapshot_lvm_snapset_name: snapset2
+            snapshot_lvm_action: snapshot
+
+        - name: Verify the snapshot LVs are createdf or snapset2
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_vg: test_vg2
+            snapshot_lvm_snapset_name: snapset2
+            snapshot_lvm_verify_only: true
+            snapshot_lvm_action: check
+
+        - name: Run the snapshot role remove the snapshot LVs for snapset1
           include_role:
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_snapset_name: snapset1
-            snapshot_lvm_vg: test_vg1
             snapshot_lvm_action: remove
 
-        - name: >-
-            Use the snapshot_lvm_verify_only option to make sure remove is done
+        - name: Use the snapshot_lvm_verify option to make sure remove is done
           include_role:
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_verify_only: true
-            snapshot_lvm_vg: test_vg1
+            snapshot_lvm_action: remove
+
+        - name: Run the snapshot role remove the snapshot LVs for snapset2
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_snapset_name: snapset2
+            snapshot_lvm_action: remove
+
+        - name: Use the snapshot_lvm_verify option to make sure remove is done
+          include_role:
+            name: linux-system-roles.snapshot
+          vars:
+            snapshot_lvm_snapset_name: snapset2
+            snapshot_lvm_verify_only: true
             snapshot_lvm_action: remove
       always:
         - name: Remove storage volumes

--- a/tests/tests_no_space_fail.yml
+++ b/tests/tests_no_space_fail.yml
@@ -38,8 +38,7 @@
             __snapshot_failed_params:
               snapshot_lvm_percent_space_required: 15
               snapshot_all: true
-              snapshot_lvm_suffix: _z
-              snapshot_lvm_prefix: a_
+              snapshot_lvm_snapset_name: snapset1
               snapshot_lvm_action: snapshot
       always:
         - name: Remove storage volumes

--- a/tests/tests_revert_basic.yml
+++ b/tests/tests_revert_basic.yml
@@ -60,8 +60,7 @@
           vars:
             snapshot_lvm_percent_space_required: 15
             snapshot_lvm_all_vgs: true
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: snapshot
 
         - name: Verify the snapshot LVs are created
@@ -69,8 +68,7 @@
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_all_vgs: true
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_verify_only: true
             snapshot_lvm_action: check
 
@@ -79,8 +77,7 @@
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_all_vgs: true
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: revert
 
         - name: Use the snapshot_lvm_verify option to make sure revert is done
@@ -88,8 +85,7 @@
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_all_vgs: true
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_verify_only: true
             snapshot_lvm_action: revert
       always:

--- a/tests/tests_single_lv.yml
+++ b/tests/tests_single_lv.yml
@@ -59,8 +59,7 @@
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_percent_space_required: 15
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
             snapshot_lvm_action: snapshot
@@ -69,8 +68,7 @@
           include_role:
             name: linux-system-roles.snapshot
           vars:
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
             snapshot_lvm_verify_only: true
@@ -80,8 +78,7 @@
           include_role:
             name: linux-system-roles.snapshot
           vars:
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
             snapshot_lvm_action: remove
@@ -91,8 +88,7 @@
           include_role:
             name: linux-system-roles.snapshot
           vars:
-            snapshot_lvm_suffix: _z
-            snapshot_lvm_prefix: a_
+            snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_verify_only: true
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1

--- a/tests/verify-role-failed.yml
+++ b/tests/verify-role-failed.yml
@@ -16,11 +16,8 @@
         snapshot_lvm_all_vgs: "{{
           __snapshot_failed_params.get('snapshot_all')
           }}"
-        snapshot_lvm_suffix: "{{
-          __snapshot_failed_params.get('snapshot_lvm_suffix')
-          }}"
-        snapshot_lvm_prefix: "{{
-          __snapshot_failed_params.get('snapshot_lvm_prefix')
+        snapshot_lvm_snapset_name: "{{
+          __snapshot_failed_params.get('snapshot_lvm_snapset_name')
           }}"
         snapshot_lvm_action: "{{
           __snapshot_failed_params.get('snapshot_lvm_action')

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -23,18 +23,15 @@ __snapshot_cmd: "{{ 'snapshot.py ' ~ snapshot_lvm_action ~ ' ' ~
   ('-r ' if snapshot_lvm_percent_space_required else '') ~ ' ' ~
   (snapshot_lvm_percent_space_required | quote
     if snapshot_lvm_percent_space_required else '') ~ ' ' ~
-  ('-p ' if snapshot_lvm_prefix else '') ~ ' ' ~
-  (snapshot_lvm_prefix | quote
-    if snapshot_lvm_prefix else '') ~ ' ' ~
   ('-vg ' if snapshot_lvm_vg else '') ~ ' ' ~
   (snapshot_lvm_vg | quote
     if snapshot_lvm_vg else '') ~ ' ' ~
   ('-lv ' if snapshot_lvm_lv else '') ~ ' ' ~
   (snapshot_lvm_lv | quote
     if snapshot_lvm_lv else '') ~ ' ' ~
-  ('-s ' if snapshot_lvm_suffix else '') ~ ' ' ~
-  (snapshot_lvm_suffix | quote
-    if snapshot_lvm_suffix else '') ~ ' ' ~
+  ('-s ' if snapshot_lvm_snapset_name else '') ~ ' ' ~
+  (snapshot_lvm_snapset_name | quote
+    if snapshot_lvm_snapset_name else '') ~ ' ' ~
   ('-g ' if snapshot_lvm_set else '') ~ ' ' ~
   (snapshot_lvm_set | to_json | quote
     if snapshot_lvm_set else '') }}"


### PR DESCRIPTION
Enhancement: add support for the "list" command

Reason: allowing the user to list snapshots that are part of a snapset is part of the MVP requirements

Result: users can list snapsets as needed.

Note: 
the PR also includes a fix to make sure snapshot size allocation is at least the LVM minimum of 512MiB.
the naming of snapsets has been simplified to just use the snapset name as a suffix - the prefix parameter has been removed.  the change will provide better compatibility with how the snapm API works.

Issue Tracker Tickets (Jira or BZ if any):
