### PR TITLE
fix: ostree test failures - use /var/mnt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,11 @@
     use: "{{ (__snapshot_is_ostree | d(false)) |
               ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
+- name: Show snapshot command
+  debug:
+    var: __snapshot_cmd
+    verbosity: 2
+
 - name: Run snapshot command {{ snapshot_lvm_action }}
   ansible.builtin.script: "{{ __snapshot_cmd }}"
   args:

--- a/tests/tests_mount.yml
+++ b/tests/tests_mount.yml
@@ -71,6 +71,16 @@
             snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: snapshot
 
+        - name: Check if system is ostree
+          stat:
+            path: /run/ostree-booted
+          register: __ostree_booted_stat
+
+        - name: Set mount point
+          set_fact:
+            __mnt: "{{ __ostree_booted_stat.stat.exists |
+              ternary('/var/mnt', '/mnt') }}"
+
         - name: Verify the snapshot LVs are created
           include_role:
             name: linux-system-roles.snapshot
@@ -88,7 +98,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Mount the snapshot for lv2
@@ -99,7 +109,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv2
-            snapshot_lvm_mountpoint: /mnt/lv2_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv2_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Mount the snapshot for lv7
@@ -110,7 +120,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv7
-            snapshot_lvm_mountpoint: /mnt/lv7_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv7_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Mount the origin for lv6
@@ -121,7 +131,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv6
-            snapshot_lvm_mountpoint: /mnt/lv6_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv6_mp' }}"
             snapshot_lvm_mountpoint_create: true
             snapshot_lvm_mount_origin: true
 
@@ -133,7 +143,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
 
         - name: Umount the snapshot for lv2
           include_role:
@@ -143,7 +153,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv2
-            snapshot_lvm_mountpoint: /mnt/lv2_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv2_mp' }}"
 
         - name: Umount the snapshot for lv7
           include_role:
@@ -153,14 +163,14 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv7
-            snapshot_lvm_mountpoint: /mnt/lv7_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv7_mp' }}"
 
         - name: Umount the origin for lv6
           include_role:
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_action: umount
-            snapshot_lvm_mountpoint: /mnt/lv6_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv6_mp' }}"
 
 
         - name: Run the snapshot role remove the snapshot LVs

--- a/tests/tests_mount_no_vg_fail.yml
+++ b/tests/tests_mount_no_vg_fail.yml
@@ -40,6 +40,16 @@
             snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: snapshot
 
+        - name: Check if system is ostree
+          stat:
+            path: /run/ostree-booted
+          register: __ostree_booted_stat
+
+        - name: Set mount point
+          set_fact:
+            __mnt: "{{ __ostree_booted_stat.stat.exists |
+              ternary('/var/mnt', '/mnt') }}"
+
         - name: Test failure of verifying wrong mount
           include_tasks: verify-role-failed.yml
           vars:
@@ -50,7 +60,7 @@
               snapshot_lvm_action: mount
               snapshot_lvm_vg: wrong_vg
               snapshot_lvm_lv: lv1
-              snapshot_lvm_mountpoint: /mnt/lv1_mp
+              snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
               snapshot_lvm_mountpoint_create: true
 
         - name: Remove the snapshot LVs

--- a/tests/tests_mount_verify.yml
+++ b/tests/tests_mount_verify.yml
@@ -71,6 +71,16 @@
             snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: snapshot
 
+        - name: Check if system is ostree
+          stat:
+            path: /run/ostree-booted
+          register: __ostree_booted_stat
+
+        - name: Set mount point
+          set_fact:
+            __mnt: "{{ __ostree_booted_stat.stat.exists |
+              ternary('/var/mnt', '/mnt') }}"
+
         - name: Verify the snapshot LVs are created
           include_role:
             name: linux-system-roles.snapshot
@@ -88,7 +98,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Mount the snapshot for lv2
@@ -99,7 +109,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv2
-            snapshot_lvm_mountpoint: /mnt/lv2_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv2_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Mount the snapshot for lv7
@@ -110,7 +120,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv7
-            snapshot_lvm_mountpoint: /mnt/lv7_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv7_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Mount the origin for lv6
@@ -121,7 +131,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv6
-            snapshot_lvm_mountpoint: /mnt/lv6_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv6_mp' }}"
             snapshot_lvm_mountpoint_create: true
             snapshot_lvm_mount_origin: true
 
@@ -133,7 +143,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
             snapshot_lvm_verify_only: true
 
 
@@ -145,7 +155,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv2
-            snapshot_lvm_mountpoint: /mnt/lv2_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv2_mp' }}"
             snapshot_lvm_verify_only: true
 
 
@@ -157,7 +167,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv7
-            snapshot_lvm_mountpoint: /mnt/lv7_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv7_mp' }}"
             snapshot_lvm_verify_only: true
 
         - name: Verify origin is mounted lv6
@@ -168,7 +178,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv6
-            snapshot_lvm_mountpoint: /mnt/lv6_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv6_mp' }}"
             snapshot_lvm_mountpoint_create: true
             snapshot_lvm_mount_origin: true
             snapshot_lvm_verify_only: true
@@ -181,7 +191,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
 
         - name: Umount the snapshot for lv2
           include_role:
@@ -191,7 +201,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv2
-            snapshot_lvm_mountpoint: /mnt/lv2_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv2_mp' }}"
 
         - name: Umount the snapshot for lv7
           include_role:
@@ -201,14 +211,14 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv7
-            snapshot_lvm_mountpoint: /mnt/lv7_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv7_mp' }}"
 
         - name: Umount the origin for lv6
           include_role:
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_action: umount
-            snapshot_lvm_mountpoint: /mnt/lv6_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv6_mp' }}"
 
         - name: Verify umount of the for lv1
           include_role:
@@ -218,7 +228,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
             snapshot_lvm_verify_only: true
 
         - name: Verify umount of the for lv2
@@ -229,7 +239,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv2
-            snapshot_lvm_mountpoint: /mnt/lv2_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv2_mp' }}"
             snapshot_lvm_verify_only: true
 
         - name: Verify umount of the for lv7
@@ -240,7 +250,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv7
-            snapshot_lvm_mountpoint: /mnt/lv7_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv7_mp' }}"
             snapshot_lvm_verify_only: true
 
         - name: Verify umount of the origin for lv6
@@ -251,7 +261,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv6
-            snapshot_lvm_mountpoint: /mnt/lv6_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv6_mp' }}"
             snapshot_lvm_verify_only: true
 
         - name: Run the snapshot role remove the snapshot LVs

--- a/tests/tests_mount_verify_fail.yml
+++ b/tests/tests_mount_verify_fail.yml
@@ -40,6 +40,16 @@
             snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: snapshot
 
+        - name: Check if system is ostree
+          stat:
+            path: /run/ostree-booted
+          register: __ostree_booted_stat
+
+        - name: Set mount point
+          set_fact:
+            __mnt: "{{ __ostree_booted_stat.stat.exists |
+              ternary('/var/mnt', '/mnt') }}"
+
         - name: Mount the snapshot for LV
           include_role:
             name: linux-system-roles.snapshot
@@ -48,7 +58,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Verify snapshot is mounted for lv1
@@ -59,7 +69,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
             snapshot_lvm_verify_only: true
 
         - name: Test failure of verifying wrong mount
@@ -72,7 +82,7 @@
               snapshot_lvm_action: mount
               snapshot_lvm_vg: test_vg1
               snapshot_lvm_lv: lv1
-              snapshot_lvm_mountpoint: /mnt/wrong_mountpoint
+              snapshot_lvm_mountpoint: "{{ __mnt ~ '/wrong_mountpoint' }}"
               snapshot_lvm_verify_only: true
 
         - name: Umount the snapshot for lv1
@@ -83,7 +93,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
 
         - name: Remove the snapshot LVs
           include_role:

--- a/tests/tests_set_mount.yml
+++ b/tests/tests_set_mount.yml
@@ -8,28 +8,27 @@
         - name: snapshot VG1 LV1
           vg: test_vg1
           lv: lv1
-          mountpoint: /mnt/lv1_mp
+          mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
           percent_space_required: 15
           mountpoint_create: true
         - name: snapshot VG2 LV3
           vg: test_vg2
           lv: lv3
-          mountpoint: /mnt/lv3_mp
+          mountpoint: "{{ __mnt ~ '/lv3_mp' }}"
           percent_space_required: 15
           mountpoint_create: true
         - name: snapshot VG2 LV4
           vg: test_vg2
           lv: lv4
-          mountpoint: /mnt/lv4_mp
+          mountpoint: "{{ __mnt ~ '/lv4_mp' }}"
           percent_space_required: 15
           mountpoint_create: true
         - name: snapshot VG3 LV7
           vg: test_vg3
           lv: lv7
-          mountpoint: /mnt/lv7_mp
+          mountpoint: "{{ __mnt ~ '/lv7_mp' }}"
           percent_space_required: 15
           mountpoint_create: true
-
 
   tasks:
     - name: Run tests
@@ -83,6 +82,16 @@
                     size: "10%"
                   - name: lv8
                     size: "10%"
+
+        - name: Check if system is ostree
+          stat:
+            path: /run/ostree-booted
+          register: __ostree_booted_stat
+
+        - name: Set mount point
+          set_fact:
+            __mnt: "{{ __ostree_booted_stat.stat.exists |
+              ternary('/var/mnt', '/mnt') }}"
 
         - name: Run the snapshot role to create a snapshot set of LVs
           include_role:

--- a/tests/tests_umount_verify.yml
+++ b/tests/tests_umount_verify.yml
@@ -71,6 +71,10 @@
             snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: snapshot
 
+        - name: Set mountpoint root directory
+          set_fact:
+            __mnt: "{{ __snapshot_is_ostree | ternary('/var/mnt', '/mnt') }}"
+
         - name: Verify the snapshot LVs are created
           include_role:
             name: linux-system-roles.snapshot
@@ -88,7 +92,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Mount the snapshot for lv2
@@ -99,7 +103,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv2
-            snapshot_lvm_mountpoint: /mnt/lv2_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv2_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Mount the snapshot for lv7
@@ -110,7 +114,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv7
-            snapshot_lvm_mountpoint: /mnt/lv7_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv7_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Mount the origin for lv6
@@ -121,7 +125,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv6
-            snapshot_lvm_mountpoint: /mnt/lv6_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv6_mp' }}"
             snapshot_lvm_mountpoint_create: true
             snapshot_lvm_mount_origin: true
 
@@ -133,7 +137,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
             snapshot_lvm_verify_only: true
 
         - name: Verify snapshot is mounted for lv2
@@ -144,7 +148,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv2
-            snapshot_lvm_mountpoint: /mnt/lv2_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv2_mp' }}"
             snapshot_lvm_verify_only: true
 
         - name: Verify snapshot is mounted for lv7
@@ -155,7 +159,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv7
-            snapshot_lvm_mountpoint: /mnt/lv7_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv7_mp' }}"
             snapshot_lvm_verify_only: true
 
         - name: Verify origin is mounted lv6
@@ -166,7 +170,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv6
-            snapshot_lvm_mountpoint: /mnt/lv6_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv6_mp' }}"
             snapshot_lvm_mountpoint_create: true
             snapshot_lvm_mount_origin: true
             snapshot_lvm_verify_only: true
@@ -179,7 +183,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
 
         - name: Umount the snapshot for lv2
           include_role:
@@ -189,7 +193,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv2
-            snapshot_lvm_mountpoint: /mnt/lv2_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv2_mp' }}"
 
         - name: Umount the snapshot for lv7
           include_role:
@@ -199,14 +203,14 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg3
             snapshot_lvm_lv: lv7
-            snapshot_lvm_mountpoint: /mnt/lv7_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv7_mp' }}"
 
         - name: Umount the origin for lv6
           include_role:
             name: linux-system-roles.snapshot
           vars:
             snapshot_lvm_action: umount
-            snapshot_lvm_mountpoint: /mnt/lv6_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv6_mp' }}"
 
         - name: Run the snapshot role remove the snapshot LVs
           include_role:

--- a/tests/tests_umount_verify_fail.yml
+++ b/tests/tests_umount_verify_fail.yml
@@ -40,6 +40,16 @@
             snapshot_lvm_snapset_name: snapset1
             snapshot_lvm_action: snapshot
 
+        - name: Check if system is ostree
+          stat:
+            path: /run/ostree-booted
+          register: __ostree_booted_stat
+
+        - name: Set mount point
+          set_fact:
+            __mnt: "{{ __ostree_booted_stat.stat.exists |
+              ternary('/var/mnt', '/mnt') }}"
+
         - name: Mount the snapshot for LV
           include_role:
             name: linux-system-roles.snapshot
@@ -48,7 +58,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
             snapshot_lvm_mountpoint_create: true
 
         - name: Verify snapshot is mounted for lv1
@@ -59,7 +69,7 @@
             snapshot_lvm_action: mount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
             snapshot_lvm_verify_only: true
 
         - name: Test failure of verifying umount when fs mounted
@@ -72,7 +82,7 @@
               snapshot_lvm_action: umount
               snapshot_lvm_vg: test_vg1
               snapshot_lvm_lv: lv1
-              snapshot_lvm_mountpoint: /mnt/lv1_mp
+              snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
               snapshot_lvm_verify_only: true
 
         - name: Umount the snapshot for lv1
@@ -83,7 +93,7 @@
             snapshot_lvm_action: umount
             snapshot_lvm_vg: test_vg1
             snapshot_lvm_lv: lv1
-            snapshot_lvm_mountpoint: /mnt/lv1_mp
+            snapshot_lvm_mountpoint: "{{ __mnt ~ '/lv1_mp' }}"
 
         - name: Remove the snapshot LVs
           include_role:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -23,7 +23,7 @@ __snapshot_cmd: "{{ 'snapshot.py ' ~ snapshot_lvm_action ~ ' ' ~
   ('-c ' if snapshot_lvm_mountpoint_create else '') ~
   ('-A ' if snapshot_lvm_unmount_all else '') ~
   ('-r ' if snapshot_lvm_percent_space_required else '') ~ ' ' ~
-  (snapshot_lvm_percent_space_required | quote
+  (snapshot_lvm_percent_space_required | string | quote
     if snapshot_lvm_percent_space_required else '') ~ ' ' ~
   ('-vg ' if snapshot_lvm_vg else '') ~ ' ' ~
   (snapshot_lvm_vg | quote


### PR DESCRIPTION
Cannot use /mnt on ostree - use /var/mnt instead

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
