### PR TITLE
test: use storage_udevadm_trigger, gather debug when fail

### DIFF
--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -8,6 +8,7 @@
   include_role:
     name: fedora.linux_system_roles.storage
   vars:
+    storage_udevadm_trigger: true  # helps with get_unused_disks, cleanup
     storage_safe_mode: false
     storage_pools: |
       {% set cleanup_pools = [] %}
@@ -47,6 +48,22 @@
     vgs --all
     cat /tmp/snapshot_role.log || :
     cat /etc/lvm/devices/system.devices || :
+    for dev in $(lsblk -l -p -o NAME); do
+      if [ "$dev" = NAME ]; then continue; fi
+      echo blkid info with cache
+      blkid "$dev" || :
+      echo blkid info without cache
+      blkid -p "$dev" || :
+    done
+    # garbage collect
+    blkid -g || :
+    echo lsblk after garbage collect
+    lsblk -p --pairs --bytes -o NAME,TYPE,SIZE,FSTYPE
+    # flush cache
+    blkid -s none || :
+    echo lsblk after cache flush
+    lsblk -p --pairs --bytes -o NAME,TYPE,SIZE,FSTYPE
+    cat /tmp/blivet.log || :
   changed_when: false
   when: unused_disks_before != unused_disks_return.disks
   failed_when: unused_disks_before != unused_disks_return.disks

--- a/tests/tasks/setup.yml
+++ b/tests/tasks/setup.yml
@@ -20,6 +20,8 @@
 - name: Run the storage role install base packages
   include_role:
     name: fedora.linux_system_roles.storage
+  vars:
+    storage_udevadm_trigger: true  # helps with get_unused_disks, cleanup
 
 - name: Get unused disks
   include_tasks: get_unused_disk.yml
@@ -32,3 +34,4 @@
     name: fedora.linux_system_roles.storage
   vars:
     storage_pools: "{{ test_storage_pools }}"
+    storage_udevadm_trigger: true  # helps with get_unused_disks, cleanup


### PR DESCRIPTION
Use `storage_udevadm_trigger: true` which seems to fix some
test failures.

Gather lots of debug information when get_unused_disks fails.