### PR TITLE
ci: tox-lsr 3.4.0 - fix py27 tests; move other checks to py310

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -58,7 +58,16 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          if [ "${{ matrix.pyver_os.ver }}" = 2.7 ]; then
+            # newer virtualenv cannot create python2 venvs
+            # newer tox requires newer virtualenv
+            tox='tox<4.15'
+            virtualenv='virtualenv<20.22.0'
+          else
+            tox=tox
+            virtualenv=virtualenv
+          fi
+          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.
@@ -73,11 +82,8 @@ jobs:
           toxenvs="py${toxpyver}"
           # NOTE: The use of flake8, pylint, black with specific
           # python envs is arbitrary and must be changed in tox-lsr
-          # We really should either do those checks using the latest
-          # version of python, or in every version of python
           case "$toxpyver" in
-          27) toxenvs="${toxenvs},coveralls,flake8,pylint" ;;
-          36) toxenvs="${toxenvs},coveralls,black" ;;
+          310) toxenvs="${toxenvs},coveralls,flake8,pylint,black" ;;
           *) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
-extends: default
 ignore: |
   /.tox/

--- a/tests/module_utils/size.py
+++ b/tests/module_utils/size.py
@@ -160,8 +160,6 @@ class Size(object):
                 exp += 1
         else:
             ftr, exp = self._parse_units(units.strip())
-            value = (
-                float(self.factor**self.exponent) / float(ftr**exp)
-            ) * self.number
+            value = (float(self.factor**self.exponent) / float(ftr**exp)) * self.number
 
         return self._format(fmt, ftr, exp) % value


### PR DESCRIPTION
The latest version of virtualenv does not support creating
python 2.7 virtualenvs.  Change our CI tests to restrict the version
of virtualenv<20.22.0 and tox<4.15 for py27 environments

Move pylint, flake8, and black checks to the py310 environment
which is currently supported by ansible-core 2.17 and its related
checkers such as ansible-lint and ansible-test

pylint now uses ansible-core 2.17 and restricts the version of
pylint to 3.1.0 which is the version used by ansible-test 2.17

Remove `extends: default` for .yamllint.yml.  The latest version
of ansible-lint will automatically incorporate local yamllint
settings unless there is an `extends:`.

The above changes require some fixes to the role code.

For more information, see
https://github.com/linux-system-roles/tox-lsr/pull/168
and
https://github.com/linux-system-roles/tox-lsr/pull/170

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
