### PR TITLE
test: should only operate on test_ vgs

### DIFF
--- a/tests/tests_thin_basic.yml
+++ b/tests/tests_thin_basic.yml
@@ -2,6 +2,8 @@
 - name: Basic snapshot test
   hosts: all
   vars:
+    # only use vgs matching this pattern
+    snapshot_lvm_vg_include: "^test_"
     test_disk_min_size: "1g"
     test_disk_count: 10
     test_storage_pools:


### PR DESCRIPTION
Tests that use `snapshot_lvm_all_vgs: true` must restrict operations
to vgs that start with `test_` to avoid conflicts with non-test vgs.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
