### PR TITLE
docs(changelog): version 1.5.0 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -58,8 +58,9 @@ SOFTWARE.
   </style>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">
+html { -webkit-text-size-adjust: 100%; }
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 .sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
@@ -70,7 +71,7 @@ div.sourceCode { overflow: auto; }
 }
 @media print {
 pre > code.sourceCode { white-space: pre-wrap; }
-pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
   { counter-reset: source-line 0; }
@@ -217,7 +218,7 @@ snapshot_lvm_percent_space_required space allocated to the snapshot.
 Allocations are rounded up to the next multiple of the volume group
 extent size.</p></li>
 <li><p><code>mount</code>: Mount a filesystem on a mount point</p></li>
-<li><p><code>umount</code>: Unmount a filesytem</p></li>
+<li><p><code>umount</code>: Unmount a filesystem</p></li>
 </ul>
 <h2 id="snapshot_lvm_set">snapshot_lvm_set</h2>
 <p>The snapshot role supports sets of volumes. Sets may contain any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 Changelog
 =========
 
+[1.5.0] - 2025-05-19
+--------------------
+
+### New Features
+
+- feat: add support for snapshot manager backing the role (#97)
+
+### Other Changes
+
+- ci: ansible-plugin-scan is disabled for now (#87)
+- ci: bump ansible-lint to v25; provide collection requirements for ansible-lint (#90)
+- ci: Check spelling with codespell (#91)
+- ci: Add test plan that runs CI tests and customize it for each role (#92)
+- ci: In test plans, prefix all relate variables with SR_ (#93)
+- ci: Fix bug with ARTIFACTS_URL after prefixing with SR_ (#94)
+- ci: several changes related to new qemu test, ansible-lint, python versions, ubuntu versions (#95)
+- ci: use tox-lsr 3.6.0; improve qemu test logging (#98)
+- ci: skip storage scsi, nvme tests in github qemu ci (#99)
+- ci: Bump sclorg/testing-farm-as-github-action from 3 to 4 (#100)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#101)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#105)
+
 [1.4.3] - 2025-01-09
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.5.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare release 1.5.0: document snapshot manager support, apply multiple CI pipeline enhancements, and tweak HTML documentation formatting and typos.

New Features:
- Add support for snapshot manager backing the role (#97)

CI:
- Disable ansible-plugin-scan and bump ansible-lint to v25 with updated requirements
- Add codespell spelling checks and refine CI test plans with SR_ prefixed variables
- Improve QEMU test logging, rename tests, and skip storage-related tests in CI
- Bump tox-lsr to 3.9.0, upgrade testing-farm GitHub Action to v4, and add Fedora 42
- Fix ARTIFACTS_URL handling after SR_ prefixing

Documentation:
- Update HTML README code block CSS rules for consistent formatting
- Fix typo in filesystem description in HTML docs