### PR TITLE
refactor: add Ansible test python boilerplate

### DIFF
--- a/module_utils/snapshot_lsr/consts.py
+++ b/module_utils/snapshot_lsr/consts.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
 class SnapshotCommand:
     SNAPSHOT = "snapshot"
     CHECK = "check"

--- a/module_utils/snapshot_lsr/lvm.py
+++ b/module_utils/snapshot_lsr/lvm.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
 import json
 import logging
 import math

--- a/module_utils/snapshot_lsr/lvm_utils.py
+++ b/module_utils/snapshot_lsr/lvm_utils.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
 import argparse
 import logging
 import json

--- a/module_utils/snapshot_lsr/snapmgr.py
+++ b/module_utils/snapshot_lsr/snapmgr.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
 import logging
 from os.path import join as path_join
 from ansible.module_utils.snapshot_lsr.consts import SnapshotStatus

--- a/module_utils/snapshot_lsr/utils.py
+++ b/module_utils/snapshot_lsr/utils.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
 import logging
 import os
 from os.path import join as path_join

--- a/module_utils/snapshot_lsr/validate.py
+++ b/module_utils/snapshot_lsr/validate.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
 import logging
 
 from ansible.module_utils.snapshot_lsr.lvm import (


### PR DESCRIPTION
ansible-test requires certain python boilerplate in module
and module_utils files.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhancements:
- Add __future__ imports (absolute_import, division, print_function) and __metaclass__ declaration to modules for ansible-test compatibility