### PR TITLE
feat: add list command to report the status of LVM snapshots for specified VGs/LVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This variable is required. It supports one of the following values:
 
 - `check`: Validate that snapshot names don't have conflicts and there is sufficient space to take the snapshots
 
+- `list`:   List the status of the specified VGs/LVs
+
 - `remove`: Remove snapshots that conform to the specified prefix and pattern
 
 - `revert`: Revert to snapshots that are specified by either the pattern or set.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ This variable is required. It supports one of the following values:
 
 - `extend`: Extend snapshot to have at least snapshot_lvm_percent_space_required
             space allocated to the snapshot.  Allocations are rounded up to the
-            next multiple of the volume group extent size.
+            next multiple of the volume group extent size. To extend a subset of
+            a snapset, update percent_space_required to the updated value for
+            the desired subset of volumes.
 
 - `mount`:  Mount a filesystem on a mount point
 

--- a/module_utils/snapshot_lsr/lvm.py
+++ b/module_utils/snapshot_lsr/lvm.py
@@ -243,8 +243,17 @@ def lvm_list_json(module, vg_name, lv_name, vg_include):
     for lv_list in vg_dict.values():
         for lv_item in lv_list:
             block_path = lv_item["lv_path"]
+            rc, is_snapshot = lvm_is_snapshot(
+                module, lv_item["vg_name"], lv_item["lv_name"]
+            )
+            if rc != SnapshotStatus.SNAPSHOT_OK:
+                raise LvmBug(
+                    "lvm_list_json: command failed for LV lvm_is_snapshot() for %s"
+                    % block_path,
+                )
+            lv_item["is_snapshot"] = is_snapshot
             fs_mount_points = get_fs_mount_points(module, block_path)
-            fs_dict[block_path] = fs_mount_points
+            fs_dict[block_path] = fs_mount_points or ""
 
     top_level["volumes"] = vg_dict
     top_level["mounts"] = fs_dict

--- a/tests/tests_list_vg.yml
+++ b/tests/tests_list_vg.yml
@@ -1,0 +1,87 @@
+---
+- name: Basic list snapshot test
+  hosts: all
+  vars:
+    # only use vgs matching this pattern
+    snapshot_lvm_vg_include: "^test_"
+    test_disk_min_size: "1g"
+    test_disk_count: 10
+    test_storage_pools:
+      - name: test_vg1
+        disks: "{{ range(0, 3) | map('extract', unused_disks) | list }}"
+        volumes:
+          - name: lv1
+            size: "15%"
+          - name: lv2
+            size: "50%"
+      - name: test_vg2
+        disks: "{{ range(3, 6) | map('extract', unused_disks) | list }}"
+        volumes:
+          - name: lv3
+            size: "10%"
+          - name: lv4
+            size: "20%"
+      - name: test_vg3
+        disks: "{{ range(6, 10) | map('extract', unused_disks) | list }}"
+        volumes:
+          - name: lv5
+            size: "30%"
+          - name: lv6
+            size: "25%"
+          - name: lv7
+            size: "10%"
+          - name: lv8
+            size: "10%"
+  tasks:
+    - name: Run tests
+      block:
+        - name: Setup
+          include_tasks: tasks/setup.yml
+
+        - name: Run the snapshot role to create snapshot LVs
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            snapshot_lvm_percent_space_required: 15
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_snapset_name: snapset1
+            snapshot_lvm_action: snapshot
+
+        - name: Verify the snapshot LVs are created
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            snapshot_lvm_all_vgs: true
+            snapshot_lvm_snapset_name: snapset1
+            snapshot_lvm_verify_only: true
+            snapshot_lvm_action: check
+
+        - name: List
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            snapshot_lvm_snapset_name: snapset1
+            snapshot_lvm_vg: test_vg2
+            snapshot_lvm_action: list
+
+        - name: Count snapshots
+          set_fact:
+            snapshot_count: "{{ snapshot_facts.volumes.values() | flatten | selectattr('is_snapshot') | list | length }}"
+
+        - name: Assert the expected 2 snapshots are listed
+          assert:
+            that: snapshot_count | int == 2
+
+        - name: Run the snapshot role remove the snapshot LVs
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            snapshot_lvm_snapset_name: snapset1
+            snapshot_lvm_action: remove
+
+        - name: Use the snapshot_lvm_verify option to make sure remove is done
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            snapshot_lvm_snapset_name: snapset1
+            snapshot_lvm_verify_only: true
+            snapshot_lvm_action: remove
+      always:
+        - name: Cleanup
+          include_tasks: tasks/cleanup.yml
+          tags: tests::cleanup

--- a/tests/tests_set_list.yml
+++ b/tests/tests_set_list.yml
@@ -1,0 +1,94 @@
+---
+- name: List and Remove Set of Snapshots
+  hosts: all
+  vars:
+    test_disk_min_size: "1g"
+    test_disk_count: 10
+    test_storage_pools:
+      - name: test_vg1
+        disks: "{{ range(0, 3) | map('extract', unused_disks) | list }}"
+        volumes:
+          - name: lv1
+            size: "15%"
+          - name: lv2
+            size: "50%"
+      - name: test_vg2
+        disks: "{{ range(3, 6) | map('extract', unused_disks) | list }}"
+        volumes:
+          - name: lv3
+            size: "10%"
+          - name: lv4
+            size: "20%"
+      - name: test_vg3
+        disks: "{{ range(6, 10) | map('extract', unused_disks) | list }}"
+        volumes:
+          - name: lv5
+            size: "30%"
+          - name: lv6
+            size: "25%"
+          - name: lv7
+            size: "10%"
+          - name: lv8
+            size: "10%"
+    snapshot_test_set:
+      name: snapset1
+      volumes:
+        - name: snapshot VG1 LV1
+          vg: test_vg1
+          lv: lv1
+          percent_space_required: 20
+        - name: snapshot VG2 LV3
+          vg: test_vg2
+          lv: lv3
+          percent_space_required: 15
+        - name: snapshot VG2 LV4
+          vg: test_vg2
+          lv: lv4
+          percent_space_required: 15
+        - name: snapshot VG3 LV7
+          vg: test_vg3
+          lv: lv7
+          percent_space_required: 15
+  tasks:
+    - name: Run tests
+      block:
+        - name: Setup
+          include_tasks: tasks/setup.yml
+
+        - name: Run the snapshot role to create snapshot set of LVs
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            snapshot_lvm_action: snapshot
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+
+        - name: List the snapshot set
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            snapshot_lvm_action: list
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+
+        - name: Count snapshots in list results
+          set_fact:
+            snapshot_count: "{{ snapshot_facts.volumes.values() | flatten | selectattr('is_snapshot') | list | length }}"
+
+        - name: Assert snapshot count matches number of volumes in the set
+          assert:
+            that: (snapshot_count | int) == (snapshot_test_set.volumes | length)
+            fail_msg: "Expected {{ snapshot_test_set.volumes | length }} snapshots but found {{ snapshot_count }}"
+
+        - name: Run remove for the set
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            snapshot_lvm_action: remove
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+
+        - name: Verify the snapshot set is removed
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            snapshot_lvm_action: remove
+            snapshot_lvm_set: "{{ snapshot_test_set }}"
+            snapshot_lvm_verify_only: true
+      always:
+        - name: Cleanup
+          include_tasks: tasks/cleanup.yml
+          tags: tests::cleanup


### PR DESCRIPTION
Enhancement:

Add list command to report the status of LVM snapshots for specified VGs/LVs

Reason:

The role lacked a way to query the current state of LVM volumes and their snapshots without performing an operation. Users had no way to programmatically inspect which LVs are snapshots, their sizes, mount status, or snapshot usage percentage from within the snapshot role.

Result:

A new list action is available via snapshot_lvm_action: list. It can be scoped to a single VG via snapshot_lvm_vg, all VGs via snapshot_lvm_all_vgs, or a specific set of volumes via snapshot_lvm_set. The command returns a structured JSON result containing per-VG volume information including an is_snapshot boolean field derived from lv_attr, mount point information for each block device, and standard LV metadata. The result is available to subsequent tasks via the snapshot_facts Ansible fact. Two new tests cover the list command: tests_list_vg.yml tests single-VG listing and tests_set_list.yml tests set-based listing with count verification.

Issue Tracker Tickets (Jira or BZ if any):

STORAGECFG-1091

## Summary by Sourcery

Add support for listing the status of LVM snapshots and expose structured snapshot metadata via Ansible facts.

New Features:
- Introduce a list action to report the status and metadata of LVM snapshots for specified volume groups and logical volumes.

Enhancements:
- Augment LVM listing data with an is_snapshot flag and normalized mount point information for each logical volume.
- Clarify documentation on using percent_space_required to extend a subset of a snapshot set.

Documentation:
- Document the new list action for querying snapshot status and usage details.

Tests:
- Add a test for listing snapshots in a single volume group using the new list action.
- Add a test for listing snapshots defined by a snapshot set and verifying the expected snapshot count.