### PR TITLE
ci: testing farm tests now use 5 managed nodes [citest_skip]

### DIFF
--- a/plans/test_playbooks_parallel.fmf
+++ b/plans/test_playbooks_parallel.fmf
@@ -13,6 +13,8 @@ provision:
     role: managed_node
   - name: managed-node4
     role: managed_node
+  - name: managed-node5
+    role: managed_node
 environment:
   # ensure versions are strings!
   SR_ANSIBLE_VER: "2.17"


### PR DESCRIPTION
snapshot needs another managed node to speed up testing

## Summary by Sourcery

CI:
- Update Testing Farm parallel test plan configuration to run with more managed nodes for faster CI runs.