### PR TITLE
test: comment out NFS mounts from /etc/fstab for bootable test failures

### DIFF
--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -3,6 +3,7 @@
 # - test_disk_min_size e.g. "1g"
 # - test_disk_count e.g. 10
 # - test_storage_pools - the list of pools & volumes to create
+# - snapshot_fstab_nfs_lines (optional, originals of NFS lines commented in setup)
 ---
 - name: Remove storage volumes
   include_role:
@@ -67,3 +68,11 @@
   changed_when: false
   when: unused_disks_before != unused_disks_return.disks
   failed_when: unused_disks_before != unused_disks_return.disks
+
+- name: Uncomment NFS fstab lines commented during setup
+  replace:
+    path: /etc/fstab
+    regexp: '^#{{ item | regex_escape }}$'
+    replace: '{{ item }}'
+  loop: "{{ snapshot_fstab_nfs_lines }}"
+  when: snapshot_fstab_nfs_lines | default([]) | length > 0

--- a/tests/tasks/setup.yml
+++ b/tests/tasks/setup.yml
@@ -6,6 +6,7 @@
 # Output:
 # - unused_disks e.g. ["sda", "sdb", ..]
 # - test_mnt_parent e.g. /mnt or /var/mnt
+# - snapshot_fstab_nfs_lines — original uncommented NFS fstab lines (commented in fstab)
 ---
 - name: Check if system is ostree
   stat:
@@ -35,3 +36,37 @@
   vars:
     storage_pools: "{{ test_storage_pools }}"
     storage_udevadm_trigger: true  # helps with get_unused_disks, cleanup
+
+- name: Reset snapshot_fstab_nfs_lines
+  set_fact:
+    snapshot_fstab_nfs_lines: []
+
+# https://github.com/snapshotmanager/snapm/issues/955
+- name: List uncommented NFS lines in /etc/fstab
+  command: >-
+    awk '!/^[[:space:]]*#/ && /[[:space:]](nfs|nfs4)[[:space:]]/' /etc/fstab
+  register: __nfs_fstab_check
+  changed_when: false
+  failed_when: __nfs_fstab_check.rc not in [0, 1, 2]
+
+- name: Comment out NFS fstab lines and save originals for cleanup
+  when: __nfs_fstab_check.stdout_lines | length > 0
+  block:
+    - name: Record original NFS fstab lines for cleanup
+      set_fact:
+        snapshot_fstab_nfs_lines: "{{ __nfs_fstab_check.stdout_lines }}"
+
+    - name: Compute fstab with NFS lines commented out
+      command: >-
+        awk '!/^[[:space:]]*#/ && /[[:space:]](nfs|nfs4)[[:space:]]/
+        { print "#" $0; next } { print }' /etc/fstab
+      register: __fstab_commented
+      changed_when: false
+
+    - name: Write /etc/fstab with NFS lines commented out
+      copy:
+        dest: /etc/fstab
+        content: "{{ __fstab_commented.stdout }}{% if __fstab_commented.stdout != '' %}\n{% endif %}"
+        owner: root
+        group: root
+        mode: "0644"


### PR DESCRIPTION
Due to https://github.com/snapshotmanager/snapm/issues/955 and due to the NFS
mounts on our test machines, the bootable tests are failing.  Comment out
the NFS mounts from /etc/fstab.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Temporarily disable NFS entries in /etc/fstab during tests to prevent bootable test failures and restore them afterward.

New Features:
- Capture and expose original uncommented NFS /etc/fstab lines as a test fact for later restoration.

Enhancements:
- Extend test setup to detect and comment out active NFS and NFS4 fstab entries before running tests.
- Extend test cleanup to restore previously commented NFS fstab entries to their original state.