### PR TITLE
fix: issues found via code review

### DIFF
--- a/module_utils/snapshot_lsr/lvm.py
+++ b/module_utils/snapshot_lsr/lvm.py
@@ -129,7 +129,7 @@ def get_json_from_args(module, module_args, vg_include):
                 )
                 continue
             volume = {}
-            volume["name"] = ("snapshot : " + vg_str + "/" + lv["lv_name"],)
+            volume["name"] = "snapshot : " + vg_str + "/" + lv["lv_name"]
             volume["vg"] = vg_str
             volume["lv"] = lv["lv_name"]
 

--- a/module_utils/snapshot_lsr/lvm.py
+++ b/module_utils/snapshot_lsr/lvm.py
@@ -96,7 +96,9 @@ def get_json_from_args(module, module_args, vg_include):
         vg_str = vg["vg_name"]
         for lv in lv_list:
 
-            if lv["lv_name"].endswith(module_args["snapshot_lvm_snapset_name"]):
+            if module_args["snapshot_lvm_snapset_name"] and lv["lv_name"].endswith(
+                module_args["snapshot_lvm_snapset_name"]
+            ):
                 logger.info(
                     "get_json_from_args: already a snapshot for %s", lv["lv_name"]
                 )

--- a/module_utils/snapshot_lsr/snapmgr.py
+++ b/module_utils/snapshot_lsr/snapmgr.py
@@ -206,7 +206,6 @@ def mgr_snapshot_cmd(module, module_args, snapset_json):
     logger.info("mgr_snapshot_cmd: %s", snapset_name)
     changed = False
     message = ""
-    rc = SnapshotStatus.SNAPSHOT_OK
     check_mode = module_args["ansible_check_mode"]
 
     rc, message = verify_snapset_source_lvs_exist(module, snapset_json)
@@ -242,7 +241,7 @@ def mgr_snapshot_cmd(module, module_args, snapset_json):
 
     if check_mode:
         return {
-            "return_code": rc,
+            "return_code": SnapshotStatus.SNAPSHOT_OK,
             "errors": "Would call function manager.create_snapshot_set()",
             "changed": False,
         }

--- a/module_utils/snapshot_lsr/snapmgr.py
+++ b/module_utils/snapshot_lsr/snapmgr.py
@@ -206,6 +206,7 @@ def mgr_snapshot_cmd(module, module_args, snapset_json):
     logger.info("mgr_snapshot_cmd: %s", snapset_name)
     changed = False
     message = ""
+    rc = SnapshotStatus.SNAPSHOT_OK
     check_mode = module_args["ansible_check_mode"]
 
     rc, message = verify_snapset_source_lvs_exist(module, snapset_json)
@@ -240,7 +241,11 @@ def mgr_snapshot_cmd(module, module_args, snapset_json):
     source_list = mgr_get_source_list_for_create(volume_list)
 
     if check_mode:
-        return {rc, "Would call function manager.create_snapshot_set()", False}
+        return {
+            "return_code": rc,
+            "errors": "Would call function manager.create_snapshot_set()",
+            "changed": False,
+        }
 
     manager = snap_manager.Manager()
 
@@ -437,9 +442,10 @@ def mgr_extend_cmd(module, module_args, snapset_json):
 
     if check_mode:
         return {
-            rc,
-            "Would run function "
-            + " manager.resize_snapshot_set() with ".join(source_list),
+            "return_code": rc,
+            "errors": "Would run function manager.resize_snapshot_set() with "
+            + ", ".join(source_list),
+            "changed": False,
         }
 
     # there are no LVs that require an extend operation, return OK.
@@ -472,9 +478,10 @@ def mgr_revert_cmd(module_args, snapset_json):
 
     if check_mode:
         return {
-            rc,
-            "Would run function "
-            + " manager.revert_snapshot_set with ".join(snapset_name),
+            "return_code": rc,
+            "errors": "Would run function manager.revert_snapshot_set with "
+            + snapset_name,
+            "changed": False,
         }
 
     manager = snap_manager.Manager()

--- a/module_utils/snapshot_lsr/snapmgr.py
+++ b/module_utils/snapshot_lsr/snapmgr.py
@@ -450,7 +450,7 @@ def mgr_extend_cmd(module, module_args, snapset_json):
 
     # there are no LVs that require an extend operation, return OK.
     if len(source_list) == 0:
-        return {"return_code": rc, "errors": "source list emmpty", "changed": changed}
+        return {"return_code": rc, "errors": "source list empty", "changed": changed}
 
     try:
         manager.resize_snapshot_set(source_list, snapset_name)
@@ -519,7 +519,7 @@ def mgr_mount_cmd(module, module_args, snapset_json):
     if snapshot_set is None or len(snapshot_set) == 0:
         return {
             "return_code": SnapshotStatus.ERROR_MOUNT_FAILED,
-            "errors": "snnapshot not found:" + snapset_name,
+            "errors": "snapshot not found: " + snapset_name,
             "changed": False,
         }
 
@@ -552,7 +552,7 @@ def mgr_umount_cmd(module, module_args, snapset_json):
     if snapshot_set is None or len(snapshot_set) == 0:
         return {
             "return_code": SnapshotStatus.ERROR_MOUNT_FAILED,
-            "errors": "snnapshot not found:" + snapset_name,
+            "errors": "snapshot not found: " + snapset_name,
             "changed": False,
         }
 

--- a/module_utils/snapshot_lsr/validate.py
+++ b/module_utils/snapshot_lsr/validate.py
@@ -79,7 +79,7 @@ def get_json_from_args(module, module_args, vg_include):
                 )
                 continue
             volume = {}
-            volume["name"] = ("snapshot : " + vg_str + "/" + lv["lv_name"],)
+            volume["name"] = "snapshot : " + vg_str + "/" + lv["lv_name"]
             volume["vg"] = vg_str
             volume["lv"] = lv["lv_name"]
 

--- a/module_utils/snapshot_lsr/validate.py
+++ b/module_utils/snapshot_lsr/validate.py
@@ -46,7 +46,9 @@ def get_json_from_args(module, module_args, vg_include):
         vg_str = vg["vg_name"]
         for lv in lv_list:
 
-            if lv["lv_name"].endswith(module_args["snapshot_lvm_snapset_name"]):
+            if module_args["snapshot_lvm_snapset_name"] and lv["lv_name"].endswith(
+                module_args["snapshot_lvm_snapset_name"]
+            ):
                 logger.info(
                     "get_json_from_args: already a snapshot for %s", lv["lv_name"]
                 )

--- a/tests/library/find_unused_disk.py
+++ b/tests/library/find_unused_disk.py
@@ -117,7 +117,8 @@ def no_holders(disk_path):
 def can_open(disk_path):
     """Return true if the device can be opened with exclusive access."""
     try:
-        os.open(disk_path, os.O_EXCL)
+        fd = os.open(disk_path, os.O_EXCL)
+        os.close(fd)
         return True
     except OSError:
         return False


### PR DESCRIPTION
Enhancement:

This PR addresses issues  in the snapshot role. The fixes include:

1. **Tuple assignment bug** - Fixed trailing commas that were creating tuples instead of strings for volume names
2. **Return statement syntax errors** - Corrected return statements that were creating sets instead of dictionaries in check_mode paths
3. **Resource leak** - Added proper file descriptor cleanup in the `can_open()` function
4. **Null pointer safety** - Added null checks before calling `.endswith()` on potentially None values
5. **Typo corrections** - Fixed user-facing error messages with spelling errors

Reason:

Code review,  issues identified:

- **Data type errors**: Volume names were being stored as tuples `('snapshot : vg/lv',)` instead of strings, which could cause unexpected behavior in string operations and serialization
- **Return value errors**: Check mode operations were returning sets `{0, "message", False}` instead of properly formatted dictionaries, causing the module to fail
- **Resource leaks**: The `find_unused_disk` module was leaking file descriptors during disk scanning operations, potentially exhausting system resources on systems with many disks
- **Crash potential**: Missing null checks could cause `AttributeError` exceptions when optional parameters are not provided
- **User experience**: Typos in error messages ("emmpty", "snnapshot") reduce professionalism and clarity

Result:

All fixes maintain backward compatibility and do not change the external API or behavior of the role.

Issue Tracker Tickets (Jira or BZ if any):

## Summary by Sourcery

Fix snapshot management role issues uncovered in review, correcting return structures, data types, error messages, and resource handling.

Bug Fixes:
- Normalize check-mode return values to proper dictionaries instead of sets in snapshot manager commands.
- Correct snapshot volume name handling to use strings instead of singleton tuples in LVM and validation helpers.
- Prevent AttributeError by guarding snapshot name endswith checks when the parameter may be absent.
- Fix user-facing error messages for snapshot operations, including typos and clearer text.
- Eliminate a file descriptor leak in the test helper by closing device handles after exclusive open attempts.

Enhancements:
- Initialize snapshot command return codes consistently before validation in snapshot manager logic.