### PR TITLE
fix: Use verbosity level 3 for no_log

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Get package facts
   package_facts:
-  no_log: "{{ ansible_verbosity < 2 }}"
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: Set snapm availability fact and version
   set_fact:


### PR DESCRIPTION
Use `ansible_verbosity < 3` instead of `< 2` to show output with `-vvv` or higher.

## Summary by Sourcery

Bug Fixes:
- Ensure package facts task output remains hidden unless Ansible is run with verbosity level 3 or higher.